### PR TITLE
feat(workflow): expose structured run results and policy providers

### DIFF
--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -231,6 +231,7 @@ defmodule Runic.Workflow do
   alias Runic.Workflow.Runnable
   alias Runic.Workflow.SchedulerPolicy
   alias Runic.Workflow.PolicyDriver
+  alias Runic.Workflow.RunResult
   alias Runic.Workflow.RunnableDispatched
   alias Runic.Workflow.RunnableCompleted
   alias Runic.Workflow.RunnableFailed
@@ -2716,17 +2717,9 @@ defmodule Runic.Workflow do
   def react(workflow, opts \\ [])
 
   def react(%__MODULE__{} = workflow, opts) when is_list(opts) do
-    if is_runnable?(workflow) do
-      {workflow, runnables} = prepare_for_dispatch(workflow)
-
-      if Keyword.get(opts, :async, false) do
-        execute_runnables_async(workflow, runnables, opts)
-      else
-        execute_runnables_serial(workflow, runnables, opts)
-      end
-    else
-      workflow
-    end
+    workflow
+    |> step(opts)
+    |> unwrap_run_result()
   end
 
   def react(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact) do
@@ -2754,29 +2747,102 @@ defmodule Runic.Workflow do
   @spec react(t(), Fact.t() | term(), keyword()) :: t()
   def react(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact, opts) do
     wrk
-    |> maybe_apply_run_context(opts)
-    |> invoke(root(), fact)
-    |> react(opts)
+    |> step(fact, opts)
+    |> unwrap_run_result()
   end
 
   def react(%__MODULE__{} = wrk, raw_fact, opts) do
     react(wrk, Fact.new(value: raw_fact), opts)
   end
 
+  @doc """
+  Executes one workflow reaction cycle and returns structured execution metadata.
+
+  Unlike `react/2`, this function returns `{:ok, %Runic.Workflow.RunResult{}}`
+  or `{:error, %Runic.Workflow.RunResult{}}`, preserving the updated workflow
+  together with cycle count, failed runnable information, and event metadata.
+  """
+  @spec step(t(), keyword()) :: {:ok, RunResult.t()} | {:error, RunResult.t()}
+  def step(workflow, opts \\ [])
+
+  def step(%__MODULE__{} = workflow, opts) when is_list(opts) do
+    opts = maybe_convert_deadline(opts)
+
+    workflow
+    |> maybe_apply_run_context(opts)
+    |> execute_step(opts)
+  end
+
+  def step(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact) do
+    step(wrk, fact, [])
+  end
+
+  def step(%__MODULE__{} = wrk, raw_fact) when not is_list(raw_fact) do
+    step(wrk, Fact.new(value: raw_fact), [])
+  end
+
+  @doc """
+  Plans input into the workflow, executes one reaction cycle, and returns
+  structured execution metadata.
+  """
+  @spec step(t(), Fact.t() | term(), keyword()) ::
+          {:ok, RunResult.t()} | {:error, RunResult.t()}
+  def step(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact, opts) do
+    opts = maybe_convert_deadline(opts)
+
+    wrk
+    |> maybe_apply_run_context(opts)
+    |> invoke(root(), fact)
+    |> execute_step(opts)
+  end
+
+  def step(%__MODULE__{} = wrk, raw_fact, opts) do
+    step(wrk, Fact.new(value: raw_fact), opts)
+  end
+
+  defp execute_step(%__MODULE__{} = workflow, opts) do
+    if is_runnable?(workflow) do
+      {workflow, runnables} = prepare_for_dispatch(workflow)
+
+      {workflow, executed, events} =
+        if Keyword.get(opts, :async, false) do
+          execute_runnables_async(workflow, runnables, opts)
+        else
+          execute_runnables_serial(workflow, runnables, opts)
+        end
+
+      step_result(workflow, executed, events)
+    else
+      {:ok, RunResult.new(workflow, :ok, cycles: 0)}
+    end
+  end
+
+  defp step_result(workflow, executed, events) do
+    case Enum.find(executed, &match?(%Runnable{status: :failed}, &1)) do
+      nil ->
+        {:ok, RunResult.new(workflow, :ok, cycles: 1, events: event_log(workflow) ++ events)}
+
+      %Runnable{} = runnable ->
+        {:error,
+         RunResult.new(workflow, :error,
+           cycles: 1,
+           failed_runnable: runnable,
+           error: runnable.error,
+           events: event_log(workflow) ++ events
+         )}
+    end
+  end
+
   defp execute_runnables_serial(workflow, runnables, opts) do
     policies = resolve_effective_policies(workflow, opts)
     driver_opts = build_driver_opts(opts)
 
-    runnables
-    |> Enum.map(fn runnable ->
-      if policies == [] do
-        Invokable.execute(runnable.node, runnable)
-      else
-        policy = SchedulerPolicy.resolve(runnable, policies)
-        PolicyDriver.execute(runnable, policy, driver_opts)
-      end
-    end)
-    |> Enum.reduce(workflow, fn executed, wrk -> apply_runnable(wrk, executed) end)
+    executed =
+      Enum.map(runnables, fn runnable ->
+        execute_runnable_with_policy(runnable, policies, driver_opts)
+      end)
+
+    apply_executed_runnables(workflow, executed)
   end
 
   defp execute_runnables_async(workflow, runnables, opts) do
@@ -2785,28 +2851,59 @@ defmodule Runic.Workflow do
     policies = resolve_effective_policies(workflow, opts)
     driver_opts = build_driver_opts(opts)
 
-    runnables
-    |> Task.async_stream(
-      fn runnable ->
-        if policies == [] do
-          Invokable.execute(runnable.node, runnable)
-        else
-          policy = SchedulerPolicy.resolve(runnable, policies)
-          PolicyDriver.execute(runnable, policy, driver_opts)
-        end
-      end,
-      max_concurrency: max_concurrency,
-      timeout: timeout
-    )
-    |> Enum.reduce(workflow, fn
-      {:ok, executed}, wrk ->
-        apply_runnable(wrk, executed)
+    executed =
+      runnables
+      |> Task.async_stream(
+        fn runnable ->
+          execute_runnable_with_policy(runnable, policies, driver_opts)
+        end,
+        max_concurrency: max_concurrency,
+        timeout: timeout
+      )
+      |> Enum.flat_map(fn
+        {:ok, executed} ->
+          [executed]
 
-      {:exit, reason}, wrk ->
-        Logger.warning("Async execution failed: #{inspect(reason)}")
-        wrk
-    end)
+        {:exit, reason} ->
+          Logger.warning("Async execution failed: #{inspect(reason)}")
+          []
+      end)
+
+    apply_executed_runnables(workflow, executed)
   end
+
+  defp execute_runnable_with_policy(runnable, policies, driver_opts) do
+    policy = SchedulerPolicy.resolve(runnable, policies)
+    PolicyDriver.execute(runnable, policy, policy_driver_opts(policy, driver_opts))
+  end
+
+  defp policy_driver_opts(%SchedulerPolicy{execution_mode: :durable}, driver_opts) do
+    Keyword.put(driver_opts, :emit_events, true)
+  end
+
+  defp policy_driver_opts(_policy, driver_opts), do: driver_opts
+
+  defp apply_executed_runnables(workflow, executed) do
+    {runnables, events} =
+      executed
+      |> Enum.map(&split_executed_runnable/1)
+      |> Enum.unzip()
+
+    workflow =
+      Enum.reduce(runnables, workflow, fn executed, wrk ->
+        apply_runnable(wrk, executed)
+      end)
+
+    {workflow, runnables, List.flatten(events)}
+  end
+
+  defp split_executed_runnable({%Runnable{} = runnable, events}) when is_list(events),
+    do: {runnable, events}
+
+  defp split_executed_runnable(%Runnable{} = runnable), do: {runnable, []}
+
+  defp unwrap_run_result({:ok, %RunResult{workflow: workflow}}), do: workflow
+  defp unwrap_run_result({:error, %RunResult{workflow: workflow}}), do: workflow
 
   defp build_driver_opts(opts) do
     case Keyword.get(opts, :deadline_at) do
@@ -2827,11 +2924,7 @@ defmodule Runic.Workflow do
     mode = Keyword.get(opts, :scheduler_policies_mode, :merge)
     base = workflow.scheduler_policies
 
-    case {runtime, mode} do
-      {nil, _} -> base
-      {_, :replace} -> runtime
-      {_, :merge} -> SchedulerPolicy.merge_policies(runtime, base)
-    end
+    SchedulerPolicy.policy_layers(runtime, base, mode)
   end
 
   @doc """
@@ -2885,25 +2978,42 @@ defmodule Runic.Workflow do
   with a custom scheduler process.
   """
   @spec react_until_satisfied(t(), Fact.t() | term(), keyword()) :: t()
-  def react_until_satisfied(workflow, fact_or_value \\ nil, opts \\ [])
-
-  def react_until_satisfied(%__MODULE__{} = workflow, nil, opts) do
-    opts = maybe_convert_deadline(opts)
-    workflow = maybe_apply_run_context(workflow, opts)
-    do_react_until_satisfied(workflow, is_runnable?(workflow), opts)
+  def react_until_satisfied(workflow, fact_or_value \\ nil, opts \\ []) do
+    workflow
+    |> run(fact_or_value, opts)
+    |> unwrap_run_result()
   end
 
-  def react_until_satisfied(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact, opts) do
+  @doc """
+  Executes the workflow until no more runnables remain and returns structured
+  execution metadata.
+
+  Options are the same as `react_until_satisfied/3`, with one addition:
+
+  - `:max_cycles` - Maximum number of reaction cycles before returning
+    `{:error, %Runic.Workflow.RunResult{status: :max_cycles}}`. Defaults to
+    `:infinity`, matching `react_until_satisfied/3` compatibility behavior.
+  """
+  @spec run(t(), Fact.t() | term(), keyword()) :: {:ok, RunResult.t()} | {:error, RunResult.t()}
+  def run(workflow, fact_or_value \\ nil, opts \\ [])
+
+  def run(%__MODULE__{} = workflow, nil, opts) do
+    opts = maybe_convert_deadline(opts)
+    workflow = maybe_apply_run_context(workflow, opts)
+    do_run(workflow, is_runnable?(workflow), opts, 0, [])
+  end
+
+  def run(%__MODULE__{} = wrk, %Fact{ancestry: nil} = fact, opts) do
     opts = maybe_convert_deadline(opts)
     wrk = maybe_apply_run_context(wrk, opts)
 
     wrk
-    |> react(fact, opts)
-    |> react_until_satisfied(nil, opts)
+    |> step(fact, opts)
+    |> continue_run(opts, 0, [])
   end
 
-  def react_until_satisfied(%__MODULE__{} = wrk, raw_fact, opts) do
-    react_until_satisfied(wrk, Fact.new(value: raw_fact), opts)
+  def run(%__MODULE__{} = wrk, raw_fact, opts) do
+    run(wrk, Fact.new(value: raw_fact), opts)
   end
 
   defp maybe_convert_deadline(opts) do
@@ -2923,19 +3033,87 @@ defmodule Runic.Workflow do
     end
   end
 
-  defp do_react_until_satisfied(%__MODULE__{} = workflow, true = _is_runnable?, opts) do
-    checkpoint = Keyword.get(opts, :checkpoint)
-
-    workflow
-    |> react(opts)
-    |> then(fn wrk ->
-      if is_function(checkpoint, 1), do: checkpoint.(wrk)
-      do_react_until_satisfied(wrk, is_runnable?(wrk), opts)
-    end)
+  defp continue_run({:error, %RunResult{} = result}, _opts, cycles_before_step, events) do
+    {:error,
+     %{
+       result
+       | cycles: cycles_before_step + result.cycles,
+         events: merge_run_events(events, result.events)
+     }}
   end
 
-  defp do_react_until_satisfied(%__MODULE__{} = workflow, false = _is_runnable?, _opts),
-    do: workflow
+  defp continue_run(
+         {:ok, %RunResult{workflow: workflow, cycles: cycles, events: step_events}},
+         opts,
+         cycles_before_step,
+         events
+       ) do
+    if cycles > 0, do: maybe_checkpoint(opts, workflow)
+
+    do_run(
+      workflow,
+      is_runnable?(workflow),
+      opts,
+      cycles_before_step + cycles,
+      merge_run_events(events, step_events)
+    )
+  end
+
+  defp do_run(%__MODULE__{} = workflow, true = _is_runnable?, opts, cycles, events) do
+    max_cycles = Keyword.get(opts, :max_cycles, :infinity)
+
+    if max_cycles != :infinity and cycles >= max_cycles do
+      {:error,
+       RunResult.new(workflow, :max_cycles,
+         cycles: cycles,
+         error: {:max_cycles, max_cycles},
+         events: merge_run_events(events, event_log(workflow))
+       )}
+    else
+      workflow
+      |> step(opts)
+      |> then(fn
+        {:ok, %RunResult{workflow: wrk, cycles: step_cycles, events: step_events}} ->
+          maybe_checkpoint(opts, wrk)
+
+          do_run(
+            wrk,
+            is_runnable?(wrk),
+            opts,
+            cycles + step_cycles,
+            merge_run_events(events, step_events)
+          )
+
+        {:error, %RunResult{} = result} ->
+          {:error,
+           %{
+             result
+             | cycles: cycles + result.cycles,
+               events: merge_run_events(events, result.events)
+           }}
+      end)
+    end
+  end
+
+  defp do_run(%__MODULE__{} = workflow, false = _is_runnable?, _opts, cycles, events) do
+    {:ok,
+     RunResult.new(workflow, :ok,
+       cycles: cycles,
+       events: merge_run_events(events, event_log(workflow))
+     )}
+  end
+
+  defp merge_run_events(left, right) do
+    (List.wrap(left) ++ List.wrap(right))
+    |> Enum.uniq()
+  end
+
+  defp maybe_checkpoint(opts, workflow) do
+    case Keyword.get(opts, :checkpoint) do
+      checkpoint when is_function(checkpoint, 1) -> checkpoint.(workflow)
+      _other -> :ok
+    end
+  end
 
   @doc """
   Removes all `%Fact{}` vertices and generation integers from the workflow graph.

--- a/lib/workflow/policy_provider.ex
+++ b/lib/workflow/policy_provider.ex
@@ -1,0 +1,30 @@
+defprotocol Runic.Workflow.PolicyProvider do
+  @fallback_to_any true
+
+  @moduledoc """
+  Optional protocol for workflow nodes that carry scheduler policy defaults.
+
+  `Runic.Workflow.SchedulerPolicy.resolve/2` consults this protocol before
+  applying workflow or runtime scheduler policy rules. This lets custom
+  components declare their own execution policy while still allowing callers to
+  override that policy from the workflow scheduler policy list.
+
+  Implementations may return:
+
+  - `nil` when the component has no policy defaults
+  - a keyword list
+  - a map
+  - a `%Runic.Workflow.SchedulerPolicy{}`
+  """
+
+  @doc """
+  Returns scheduler policy defaults for this workflow node.
+  """
+  @spec scheduler_policy(node :: struct()) ::
+          Runic.Workflow.SchedulerPolicy.t() | map() | keyword() | nil
+  def scheduler_policy(node)
+end
+
+defimpl Runic.Workflow.PolicyProvider, for: Any do
+  def scheduler_policy(_node), do: nil
+end

--- a/lib/workflow/run_result.ex
+++ b/lib/workflow/run_result.ex
@@ -1,0 +1,46 @@
+defmodule Runic.Workflow.RunResult do
+  @moduledoc """
+  Structured outcome returned by result-oriented workflow execution.
+
+  `Runic.Workflow.react/2` and `react_until_satisfied/3` keep returning the
+  updated workflow for compatibility. `Runic.Workflow.step/3` and
+  `Runic.Workflow.run/3` return this struct when callers need execution status,
+  cycle count, failed runnable details, and the final workflow together.
+  """
+
+  alias Runic.Workflow
+  alias Runic.Workflow.Runnable
+
+  defstruct [
+    :workflow,
+    :status,
+    :cycles,
+    :failed_runnable,
+    :error,
+    :events
+  ]
+
+  @type status :: :ok | :error | :max_cycles
+
+  @type t :: %__MODULE__{
+          workflow: Workflow.t(),
+          status: status(),
+          cycles: non_neg_integer(),
+          failed_runnable: Runnable.t() | nil,
+          error: term() | nil,
+          events: [term()]
+        }
+
+  @doc false
+  @spec new(Workflow.t(), status(), keyword()) :: t()
+  def new(%Workflow{} = workflow, status, opts \\ []) when is_list(opts) do
+    %__MODULE__{
+      workflow: workflow,
+      status: status,
+      cycles: Keyword.get(opts, :cycles, 0),
+      failed_runnable: Keyword.get(opts, :failed_runnable),
+      error: Keyword.get(opts, :error),
+      events: Keyword.get_lazy(opts, :events, fn -> Workflow.event_log(workflow) end)
+    }
+  end
+end

--- a/lib/workflow/scheduler_policy.ex
+++ b/lib/workflow/scheduler_policy.ex
@@ -5,9 +5,15 @@ defmodule Runic.Workflow.SchedulerPolicy do
   A `SchedulerPolicy` controls retry behavior, timeouts, failure handling,
   execution mode, and other scheduling concerns for individual workflow nodes.
 
-  Policies are resolved at runtime by matching against runnable nodes using
-  a list of `{matcher, policy_map}` tuples. The first matching rule wins,
-  and its policy map is merged over the default policy.
+  Flat policy lists are resolved by merging the first matching policy over
+  Runic defaults and component defaults. Layered policy resolution, used by
+  `Runic.Workflow.run/3` and `Runic.Workflow.step/3`, applies these sources
+  from lowest to highest precedence:
+
+  1. Runic defaults
+  2. The first matching workflow policy
+  3. Component defaults from `Runic.Workflow.PolicyProvider`
+  4. The first matching runtime policy
 
   ## Matcher Types
 
@@ -57,7 +63,8 @@ defmodule Runic.Workflow.SchedulerPolicy do
       policy = SchedulerPolicy.resolve(runnable, policies)
   """
 
-  alias Runic.Workflow.Runnable
+  alias Runic.Workflow.{PolicyProvider, Runnable}
+  alias Runic.Workflow.SchedulerPolicy.Layers
 
   @known_keys [
     :max_retries,
@@ -138,24 +145,30 @@ defmodule Runic.Workflow.SchedulerPolicy do
   def default_policy, do: %__MODULE__{}
 
   @doc """
-  Resolves a `SchedulerPolicy` for a given runnable by walking a list of
-  `{matcher, policy_map}` tuples top-to-bottom. First match wins.
+  Resolves a `SchedulerPolicy` for a given runnable.
 
-  The matched policy map is merged over the default policy. If no match is
-  found or `policies` is `nil` or `[]`, returns the default policy.
+  Component policy defaults from `Runic.Workflow.PolicyProvider` are merged over
+  Runic defaults. The first matching policy rule, if any, is merged last and
+  takes precedence over both.
   """
-  @spec resolve(Runnable.t(), list() | nil) :: t()
-  def resolve(%Runnable{}, nil), do: %__MODULE__{}
-  def resolve(%Runnable{}, []), do: %__MODULE__{}
+  @spec resolve(Runnable.t(), list() | Layers.t() | nil) :: t()
+  def resolve(%Runnable{} = runnable, nil), do: resolve(runnable, [])
+
+  def resolve(%Runnable{node: node}, %Layers{} = layers) do
+    %__MODULE__{}
+    |> Map.from_struct()
+    |> Map.merge(matching_policy_map(node, layers.workflow))
+    |> Map.merge(provider_policy_map(node))
+    |> Map.merge(matching_policy_map(node, layers.runtime))
+    |> new()
+  end
 
   def resolve(%Runnable{node: node}, policies) when is_list(policies) do
-    case Enum.find(policies, fn {matcher, _policy_map} -> matches?(matcher, node) end) do
-      {_matcher, policy_map} ->
-        struct!(__MODULE__, Map.merge(Map.from_struct(%__MODULE__{}), policy_map))
-
-      nil ->
-        %__MODULE__{}
-    end
+    %__MODULE__{}
+    |> Map.from_struct()
+    |> Map.merge(provider_policy_map(node))
+    |> Map.merge(matching_policy_map(node, policies))
+    |> new()
   end
 
   @doc """
@@ -176,6 +189,24 @@ defmodule Runic.Workflow.SchedulerPolicy do
   def merge_policies([], workflow_base, _mode), do: workflow_base
   def merge_policies(overrides, _workflow_base, :replace), do: overrides
   def merge_policies(overrides, workflow_base, :merge), do: overrides ++ workflow_base
+
+  @doc """
+  Builds layered policy configuration for workflow execution.
+
+  Layered policy resolution lets `Workflow.run/3` preserve runtime overrides as
+  a distinct layer above component-provided policy defaults while keeping
+  workflow scheduler policies below component policy.
+  """
+  @spec policy_layers(list() | nil, list() | nil, :merge | :replace) :: Layers.t()
+  def policy_layers(runtime_overrides, workflow_base, mode \\ :merge)
+
+  def policy_layers(runtime_overrides, _workflow_base, :replace) do
+    %Layers{workflow: [], runtime: runtime_overrides || []}
+  end
+
+  def policy_layers(runtime_overrides, workflow_base, :merge) do
+    %Layers{workflow: workflow_base || [], runtime: runtime_overrides || []}
+  end
 
   # ---------------------------------------------------------------------------
   # Presets
@@ -235,6 +266,24 @@ defmodule Runic.Workflow.SchedulerPolicy do
   # ---------------------------------------------------------------------------
   # Matchers
   # ---------------------------------------------------------------------------
+
+  defp provider_policy_map(node) do
+    node
+    |> PolicyProvider.scheduler_policy()
+    |> normalize_policy_map()
+  end
+
+  defp matching_policy_map(node, policies) do
+    case Enum.find(policies, fn {matcher, _policy_map} -> matches?(matcher, node) end) do
+      {_matcher, policy_map} -> normalize_policy_map(policy_map)
+      nil -> %{}
+    end
+  end
+
+  defp normalize_policy_map(nil), do: %{}
+  defp normalize_policy_map(%__MODULE__{} = policy), do: Map.from_struct(policy)
+  defp normalize_policy_map(policy) when is_list(policy), do: Map.new(policy)
+  defp normalize_policy_map(policy) when is_map(policy), do: policy
 
   defp matches?(matcher, node) when is_atom(matcher) and matcher != :default do
     case Map.get(node, :name) do

--- a/lib/workflow/scheduler_policy/layers.ex
+++ b/lib/workflow/scheduler_policy/layers.ex
@@ -1,0 +1,10 @@
+defmodule Runic.Workflow.SchedulerPolicy.Layers do
+  @moduledoc false
+
+  defstruct workflow: [], runtime: []
+
+  @type t :: %__MODULE__{
+          workflow: list(),
+          runtime: list()
+        }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Runic.MixProject do
           Runic.Workflow.Join
         ],
         "Scheduling & Execution": [
+          Runic.Workflow.RunResult,
           Runic.Workflow.SchedulerPolicy,
           Runic.Workflow.PolicyDriver,
           Runic.Workflow.RunnableDispatched,

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule Runic.MixProject do
         ],
         Protocols: [
           Runic.Workflow.Invokable,
+          Runic.Workflow.PolicyProvider,
           Runic.Component,
           Runic.Transmutable
         ],

--- a/test/scheduler_policy_test.exs
+++ b/test/scheduler_policy_test.exs
@@ -3,6 +3,7 @@ defmodule Runic.Workflow.SchedulerPolicyTest do
 
   alias Runic.Workflow.SchedulerPolicy
   alias Runic.Workflow.{Step, Condition, Fact, CausalContext, Runnable}
+  alias Runic.Test.PolicyProviderNode
 
   defp make_runnable(name, struct_mod \\ Step) do
     node =
@@ -11,6 +12,13 @@ defmodule Runic.Workflow.SchedulerPolicyTest do
         Condition -> Condition.new(work: fn _ -> true end, name: name, arity: 1)
       end
 
+    fact = Fact.new(value: :test)
+    context = CausalContext.new(node_hash: node.hash, input_fact: fact, ancestry_depth: 0)
+    Runnable.new(node, fact, context)
+  end
+
+  defp make_policy_provider_runnable(name, policy) do
+    node = %PolicyProviderNode{name: name, hash: :erlang.phash2({name, policy}), policy: policy}
     fact = Fact.new(value: :test)
     context = CausalContext.new(node_hash: node.hash, input_fact: fact, ancestry_depth: 0)
     Runnable.new(node, fact, context)
@@ -262,6 +270,77 @@ defmodule Runic.Workflow.SchedulerPolicyTest do
       assert result.max_retries == 3
       assert result.backoff == :none
       assert result.timeout_ms == :infinity
+      assert result.on_failure == :halt
+    end
+
+    test "component policy provider is merged over defaults without explicit policies" do
+      runnable = make_policy_provider_runnable(:provided, max_retries: 2, timeout_ms: 1_000)
+
+      result = SchedulerPolicy.resolve(runnable, [])
+
+      assert result.max_retries == 2
+      assert result.timeout_ms == 1_000
+      assert result.backoff == :none
+    end
+
+    test "matching explicit policy overrides component policy provider" do
+      runnable = make_policy_provider_runnable(:provided, max_retries: 2, timeout_ms: 1_000)
+
+      result = SchedulerPolicy.resolve(runnable, provided: %{max_retries: 5})
+
+      assert result.max_retries == 5
+      assert result.timeout_ms == 1_000
+    end
+
+    test "policy provider accepts SchedulerPolicy structs" do
+      provider_policy = SchedulerPolicy.fast_fail()
+      runnable = make_policy_provider_runnable(:provided, provider_policy)
+
+      result = SchedulerPolicy.resolve(runnable, [])
+
+      assert result.max_retries == 0
+      assert result.timeout_ms == 5_000
+      assert result.on_failure == :halt
+    end
+
+    test "policy provider validates unknown keys" do
+      runnable = make_policy_provider_runnable(:provided, bogus_key: true)
+
+      assert_raise ArgumentError, ~r/unknown keys/, fn ->
+        SchedulerPolicy.resolve(runnable, [])
+      end
+    end
+
+    test "layered policies put provider defaults above workflow and below runtime" do
+      runnable =
+        make_policy_provider_runnable(:provided, max_retries: 2, timeout_ms: 1_000)
+
+      policies =
+        SchedulerPolicy.policy_layers(
+          [provided: %{max_retries: 5}],
+          provided: %{max_retries: 0, timeout_ms: 100}
+        )
+
+      result = SchedulerPolicy.resolve(runnable, policies)
+
+      assert result.max_retries == 5
+      assert result.timeout_ms == 1_000
+    end
+
+    test "layered replace mode ignores workflow policies" do
+      runnable = make_policy_provider_runnable(:provided, max_retries: 2)
+
+      policies =
+        SchedulerPolicy.policy_layers(
+          [provided: %{timeout_ms: 50}],
+          [provided: %{timeout_ms: 10, on_failure: :skip}],
+          :replace
+        )
+
+      result = SchedulerPolicy.resolve(runnable, policies)
+
+      assert result.max_retries == 2
+      assert result.timeout_ms == 50
       assert result.on_failure == :halt
     end
   end

--- a/test/support/policy_provider_node.ex
+++ b/test/support/policy_provider_node.ex
@@ -1,0 +1,9 @@
+defmodule Runic.Test.PolicyProviderNode do
+  @moduledoc false
+
+  defstruct [:name, :hash, :policy]
+end
+
+defimpl Runic.Workflow.PolicyProvider, for: Runic.Test.PolicyProviderNode do
+  def scheduler_policy(%{policy: policy}), do: policy
+end

--- a/test/workflow/run_result_test.exs
+++ b/test/workflow/run_result_test.exs
@@ -1,0 +1,116 @@
+defmodule Runic.Workflow.RunResultTest do
+  use ExUnit.Case, async: true
+  @moduletag capture_log: true
+
+  alias Runic.Workflow
+  alias Runic.Workflow.{RunnableCompleted, RunnableDispatched}
+  alias Runic.Workflow.RunResult
+
+  require Runic
+
+  describe "step/3" do
+    test "returns a structured result for one reaction cycle" do
+      workflow = Runic.workflow(steps: [Runic.step(fn x -> x * 2 end, name: :double)])
+
+      assert {:ok, %RunResult{status: :ok, cycles: 1, workflow: stepped} = result} =
+               Workflow.step(workflow, 5)
+
+      assert result.failed_runnable == nil
+      assert result.error == nil
+      assert Workflow.raw_productions(stepped) == [10]
+      assert result.events != []
+    end
+
+    test "returns failure metadata without changing react/3 compatibility" do
+      workflow =
+        Runic.workflow(steps: [Runic.step(fn _input -> raise "boom" end, name: :explode)])
+        |> Workflow.set_scheduler_policies([{:default, %{max_retries: 0}}])
+
+      assert {:error,
+              %RunResult{
+                status: :error,
+                cycles: 1,
+                failed_runnable: failed,
+                error: %RuntimeError{message: "boom"},
+                workflow: stepped
+              }} = Workflow.step(workflow, :input)
+
+      assert failed.status == :failed
+      assert Workflow.raw_productions(stepped) == []
+      assert %Workflow{} = Workflow.react(workflow, :input)
+    end
+  end
+
+  describe "run/3" do
+    test "runs until no runnables remain and returns cycle metadata" do
+      workflow =
+        Runic.workflow(
+          steps: [
+            {Runic.step(fn x -> x + 1 end, name: :add),
+             [Runic.step(fn x -> x * 2 end, name: :double)]}
+          ]
+        )
+
+      assert {:ok, %RunResult{status: :ok, cycles: 2, workflow: ran}} =
+               Workflow.run(workflow, 5)
+
+      assert Enum.sort(Workflow.raw_productions(ran)) == [6, 12]
+      refute Workflow.is_runnable?(ran)
+    end
+
+    test "returns max_cycles without discarding the partial workflow" do
+      workflow =
+        Runic.workflow(
+          steps: [
+            {Runic.step(fn x -> x + 1 end, name: :add),
+             [Runic.step(fn x -> x * 2 end, name: :double)]}
+          ]
+        )
+
+      assert {:error,
+              %RunResult{
+                status: :max_cycles,
+                cycles: 1,
+                error: {:max_cycles, 1},
+                workflow: partial
+              }} = Workflow.run(workflow, 5, max_cycles: 1)
+
+      assert Workflow.raw_productions(partial) == [6]
+      assert Workflow.is_runnable?(partial)
+    end
+
+    test "calls checkpoints after each completed cycle including the initial input cycle" do
+      checkpoints = start_supervised!({Agent, fn -> [] end})
+      workflow = Runic.workflow(steps: [Runic.step(fn x -> x + 1 end, name: :add)])
+
+      assert {:ok, %RunResult{cycles: 1}} =
+               Workflow.run(workflow, 5,
+                 checkpoint: fn wrk ->
+                   Agent.update(checkpoints, fn states ->
+                     [Workflow.raw_productions(wrk) | states]
+                   end)
+                 end
+               )
+
+      assert [[6]] = Agent.get(checkpoints, &Enum.reverse/1)
+    end
+
+    test "react_until_satisfied/3 keeps returning the workflow" do
+      workflow = Runic.workflow(steps: [Runic.step(fn x -> x * 3 end, name: :triple)])
+
+      assert %Workflow{} = ran = Workflow.react_until_satisfied(workflow, 7)
+      assert Workflow.raw_productions(ran) == [21]
+    end
+
+    test "emits runnable lifecycle events for durable local execution" do
+      workflow =
+        Runic.workflow(steps: [Runic.step(fn x -> x + 1 end, name: :add)])
+        |> Workflow.set_scheduler_policies(add: %{execution_mode: :durable})
+
+      assert {:ok, %RunResult{events: events}} = Workflow.run(workflow, 5)
+
+      assert Enum.any?(events, &match?(%RunnableDispatched{}, &1))
+      assert Enum.any?(events, &match?(%RunnableCompleted{}, &1))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add structured workflow execution results via Runic.Workflow.RunResult
- add Workflow.step/2,3 and Workflow.run/1,2,3 while preserving react/* return compatibility
- preserve lifecycle events across full Workflow.run/3 execution, including durable local execution
- add Runic.Workflow.PolicyProvider so components can supply scheduler policy defaults
- add layered policy resolution for Workflow.run/step: Runic defaults < workflow policy < component provider < runtime policy

## Tests
- runic: mix test
- runic focused: mix test test/workflow/run_result_test.exs test/scheduler_policy_test.exs
- jido_action: mix test with {:runic, path: "../runic", override: true}

## Notes
- This is one PR with two commits: structured run results first, component policy providers/layered policy resolution second.
