### PR TITLE
Fix grouped connection replay

### DIFF
--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -806,36 +806,14 @@ defmodule Runic.Workflow do
   """
   def add_with_events(%__MODULE__{} = workflow, component, opts \\ []) do
     to = opts[:to]
-
-    parent_step =
-      if not is_nil(to) do
-        get_component(workflow, to) ||
-          get_by_hash(workflow, to) ||
-          root()
-      else
-        root()
-      end
-
     events = build_events(component, to)
 
     workflow =
-      component
-      |> Component.connect(parent_step, workflow)
+      workflow
+      |> add(component, Keyword.put(opts, :log, false))
       |> append_build_log(events)
 
-    # |> maybe_put_component(component)
-
     {workflow, events}
-  end
-
-  defp build_events(component, parents) when is_list(parents) do
-    Enum.reduce(parents, [], fn parent, events ->
-      events ++ build_events(component, parent)
-    end)
-  end
-
-  defp build_events(component, %{name: name}) do
-    build_events(component, name)
   end
 
   defp build_events(component, parent) do
@@ -845,7 +823,7 @@ defmodule Runic.Workflow do
       %ComponentAdded{
         closure: closure,
         name: component.name,
-        to: parent,
+        to: durable_parent_ref(parent),
         hash: Map.get(component, :hash),
         # Backward compatibility: also set source/bindings for old deserialization
         source: Component.source(component),
@@ -854,30 +832,22 @@ defmodule Runic.Workflow do
     ]
   end
 
+  defp durable_parent_ref(parents) when is_list(parents),
+    do: Enum.map(parents, &durable_parent_ref/1)
+
+  defp durable_parent_ref(%Root{}), do: nil
+  defp durable_parent_ref(%{name: name}), do: name
+  defp durable_parent_ref(parent), do: parent
+
   defp append_build_log(%__MODULE__{build_log: bl} = workflow, events) when is_list(events) do
     %__MODULE__{
       workflow
-      | build_log: bl ++ events
+      | build_log: Enum.reverse(events) ++ bl
     }
   end
 
-  defp append_build_log(%__MODULE__{} = workflow, component, %Root{} = parent) do
-    do_append_build_log(workflow, component, parent)
-  end
-
-  defp append_build_log(%__MODULE__{} = workflow, component, parents) when is_list(parents) do
-    Enum.reduce(parents, workflow, fn parent, wrk ->
-      append_build_log(wrk, component, parent)
-    end)
-  end
-
-  defp append_build_log(%__MODULE__{} = workflow, component, %{name: name}) do
-    do_append_build_log(workflow, component, name)
-  end
-
-  defp append_build_log(%__MODULE__{} = workflow, component, to) do
-    do_append_build_log(workflow, component, to)
-  end
+  defp append_build_log(%__MODULE__{} = workflow, component, parent),
+    do: do_append_build_log(workflow, component, durable_parent_ref(parent))
 
   defp do_append_build_log(%__MODULE__{build_log: bl} = workflow, component, parent) do
     # Use new closure field if available, otherwise fall back to old format
@@ -1187,10 +1157,44 @@ defmodule Runic.Workflow do
       rebuilt = Workflow.apply_events(Workflow.new(), events1 ++ events2)
   """
   def apply_events(%__MODULE__{} = wrk, events) when is_list(events) do
-    Enum.reduce(events, wrk, fn event, acc ->
+    events
+    |> normalize_legacy_component_groups()
+    |> Enum.reduce(wrk, fn event, acc ->
       apply_event(acc, event)
     end)
   end
+
+  defp normalize_legacy_component_groups(events) do
+    events
+    |> Enum.reduce([], fn event, reversed ->
+      case reversed do
+        [%ComponentAdded{} = previous | rest] ->
+          if legacy_group_member?(previous, event) do
+            grouped_to = Enum.uniq(List.wrap(previous.to) ++ List.wrap(event.to))
+            [%ComponentAdded{previous | to: grouped_to} | rest]
+          else
+            [event | reversed]
+          end
+
+        _ ->
+          [event | reversed]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp legacy_group_member?(%ComponentAdded{} = previous, %ComponentAdded{} = event) do
+    not is_nil(previous.to) and not is_nil(event.to) and
+      component_event_identity(previous) == component_event_identity(event) and
+      event.to not in List.wrap(previous.to)
+  end
+
+  defp legacy_group_member?(_previous, _event), do: false
+
+  defp component_event_identity(%ComponentAdded{hash: hash}) when not is_nil(hash),
+    do: {:hash, hash}
+
+  defp component_event_identity(%ComponentAdded{name: name}), do: {:name, name}
 
   defp component_from_added(
          %ComponentAdded{source: source, bindings: bindings, closure: closure} = event
@@ -1262,6 +1266,12 @@ defmodule Runic.Workflow do
   @doc """
   Rebuilds a workflow from a list of `%ComponentAdded{}` and/or `%ReactionOccurred{}` events.
 
+  Multi-parent additions are stored as one `%ComponentAdded{to: parents}` event.
+  For compatibility with older logs, consecutive `ComponentAdded` events with
+  the same component hash (or name when no hash is present) are treated as one
+  grouped addition. Non-consecutive events remain independent construction
+  decisions.
+
   ## Examples
 
       require Runic
@@ -1276,7 +1286,9 @@ defmodule Runic.Workflow do
       # => [10]
   """
   def from_log(events) do
-    Enum.reduce(events, new(), fn
+    events
+    |> normalize_legacy_component_groups()
+    |> Enum.reduce(new(), fn
       %ComponentAdded{} = event, wrk ->
         component = component_from_added(event)
 

--- a/test/workflow/grouped_replay_test.exs
+++ b/test/workflow/grouped_replay_test.exs
@@ -1,0 +1,111 @@
+defmodule Runic.Workflow.GroupedReplayTest do
+  use ExUnit.Case, async: true
+
+  require Runic
+
+  alias Runic.Workflow
+  alias Runic.Workflow.{ComponentAdded, Join, Root}
+
+  describe "grouped component replay" do
+    test "preserves one multi-parent construction decision and its logical and compiled graphs" do
+      original = grouped_workflow()
+      build_log = Workflow.build_log(original)
+      serialized_log = build_log |> :erlang.term_to_binary() |> :erlang.binary_to_term()
+
+      assert %ComponentAdded{name: :sum, to: [:a, :b]} = List.last(serialized_log)
+
+      rebuilt = Workflow.from_log(serialized_log)
+
+      assert edge_inventory(original, :connects_to) == edge_inventory(rebuilt, :connects_to)
+      assert edge_inventory(original, :flow) == edge_inventory(rebuilt, :flow)
+
+      for workflow <- [original, rebuilt] do
+        assert Enum.count(Multigraph.vertices(workflow.graph), &match?(%Join{}, &1)) == 1
+
+        assert workflow
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:sum) == [16]
+      end
+    end
+
+    test "add_with_events emits one grouped event and rebuilds through the Join path" do
+      a = Runic.step(fn value -> value + 1 end, name: :a)
+      b = Runic.step(fn value -> value * 2 end, name: :b)
+      sum = Runic.step(fn left, right -> left + right end, name: :sum)
+
+      {workflow, events_a} = Workflow.add_with_events(Workflow.new(), a)
+      {workflow, events_b} = Workflow.add_with_events(workflow, b)
+      {original, events_sum} = Workflow.add_with_events(workflow, sum, to: [:a, :b])
+
+      assert [%ComponentAdded{name: :sum, to: [:a, :b]}] = events_sum
+
+      rebuilt = Workflow.apply_events(Workflow.new(), events_a ++ events_b ++ events_sum)
+
+      assert edge_inventory(original, :connects_to) == edge_inventory(rebuilt, :connects_to)
+      assert edge_inventory(original, :flow) == edge_inventory(rebuilt, :flow)
+
+      assert rebuilt
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:sum) == [16]
+    end
+
+    test "coalesces consecutive legacy events for the same component identity" do
+      workflow = grouped_workflow()
+      [a_event, b_event, %ComponentAdded{} = grouped_sum] = Workflow.build_log(workflow)
+
+      legacy_events = [
+        a_event,
+        b_event,
+        %ComponentAdded{grouped_sum | to: :a},
+        %ComponentAdded{grouped_sum | to: :b}
+      ]
+
+      rebuilt = Workflow.from_log(legacy_events)
+
+      assert Enum.count(Multigraph.vertices(rebuilt.graph), &match?(%Join{}, &1)) == 1
+
+      assert rebuilt
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:sum) == [16]
+    end
+
+    test "keeps a legacy single-parent event compatible" do
+      parent = Runic.step(fn value -> value + 1 end, name: :parent)
+      child = Runic.step(fn value -> value * 2 end, name: :child)
+
+      workflow = Workflow.new() |> Workflow.add(parent) |> Workflow.add(child, to: :parent)
+      [parent_event, %ComponentAdded{} = child_event] = Workflow.build_log(workflow)
+
+      assert child_event.to == :parent
+
+      rebuilt = Workflow.from_log([parent_event, child_event])
+
+      assert rebuilt
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:child) == [12]
+    end
+  end
+
+  defp grouped_workflow do
+    a = Runic.step(fn value -> value + 1 end, name: :a)
+    b = Runic.step(fn value -> value * 2 end, name: :b)
+    sum = Runic.step(fn left, right -> left + right end, name: :sum)
+
+    Workflow.new()
+    |> Workflow.add(a)
+    |> Workflow.add(b)
+    |> Workflow.add(sum, to: [:a, :b])
+  end
+
+  defp edge_inventory(workflow, label) do
+    workflow.graph
+    |> Multigraph.edges(by: label)
+    |> Enum.map(fn edge -> {node_identity(edge.v1), node_identity(edge.v2), edge.label} end)
+    |> Enum.sort()
+  end
+
+  defp node_identity(%Root{}), do: :root
+  defp node_identity(%Join{joins: joins}), do: {:join, joins}
+  defp node_identity(%{name: name}) when not is_nil(name), do: {:component, name}
+  defp node_identity(%{hash: hash}), do: {:node, hash}
+end

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -2216,12 +2216,9 @@ defmodule WorkflowTest do
       combined_events = events1 ++ events2 ++ events3
       build_log = Workflow.build_log(final_workflow)
 
-      # build_log reverses the internal log which is appended by add_with_events
-      # so build_log output should be in reverse order of combined_events
       assert length(combined_events) == length(build_log)
 
-      # Compare by reversing the build_log to match combined_events order
-      for {combined, logged} <- Enum.zip(combined_events, Enum.reverse(build_log)) do
+      for {combined, logged} <- Enum.zip(combined_events, build_log) do
         assert combined.name == logged.name
         assert combined.to == logged.to
         assert combined.closure == logged.closure


### PR DESCRIPTION
## Summary

- preserve multi-parent `to:` lists as one durable `ComponentAdded` construction decision
- route `add_with_events/3` through the same validated `Workflow.add/3` path and keep its build log chronological
- replay grouped additions through the existing `Component.connect/3` lowering so the `Join` is reconstructed
- coalesce consecutive legacy `ComponentAdded` records with the same component identity into one parent group
- retain legacy single-parent replay behavior

This implements the first, grouped-replay PR scoped in #11. Named-port connection data and runtime input lowering remain follow-up work.

## Replay invariant

The focused coverage proves that an original and rebuilt multi-parent workflow have equivalent:

- logical `:connects_to` edges
- compiled `:flow` edges
- serialized construction data
- observable output (`:sum` produces `16` exactly once)

For older logs, only consecutive repeated component events with the same hash (or name when no hash exists) are grouped. Non-consecutive records remain independent construction decisions.

## Local verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` — 55 doctests, 1,337 tests, 0 failures, 13 skipped
- `mix docs` — completed; only existing hidden-event reference warnings

Runic currently has no `mix precommit` task, so the repository-equivalent checks above were run individually.
