### PR TITLE
Add durable named-port connection lowering

### DIFF
--- a/guides/cheatsheet.md
+++ b/guides/cheatsheet.md
@@ -29,8 +29,10 @@ step = Runic.step(&String.upcase/1)
 # With name (recommended for debugging and referencing in workflows)
 step = Runic.step(fn x -> x + 1 end, name: :increment)
 
-# Multi-arity (requires 2-element list input)
-step = Runic.step(fn a, b -> a + b end)
+# Multi-arity (receives values in declared input-port order)
+step = Runic.step(fn left, right -> left + right end,
+  inputs: [left: [type: :integer], right: [type: :integer]]
+)
 
 # Pin runtime variables (required for serialization)
 multiplier = 3
@@ -293,6 +295,106 @@ workflow = Workflow.new()
   |> Workflow.add(join_step, to: [:a, :b])     # Join multiple parents
 ```
 
+Use `to:` for ordinary whole-value flow. Use `connections:` when authored ports,
+value projection, or input assembly are part of the workflow contract. The two
+options are mutually exclusive.
+
+### Named Port Connections
+
+Each connection names a source component and output port in `from:` and a
+target input port in `to:`. All connections passed while adding a component are
+validated and lowered as one input assignment:
+
+```elixir
+producer = Runic.step(fn input -> %{left: input + 1, right: input * 2} end,
+  name: :producer,
+  outputs: [left: [type: :integer], right: [type: :integer]]
+)
+
+sum = Runic.step(fn left, right -> left + right end,
+  name: :sum,
+  inputs: [left: [type: :integer], right: [type: :integer]]
+)
+
+workflow =
+  Workflow.new()
+  |> Workflow.add(producer)
+  |> Workflow.add(sum,
+    connections: [
+      [from: {:producer, :left}, to: :left],
+      [from: {:producer, :right}, to: :right]
+    ]
+  )
+```
+
+For a source with one declared output, that port represents the whole produced
+value. For multiple declared outputs, Runic reads the named value from a map or
+keyword result, or by output position from a tuple or list.
+
+Connection fields:
+
+| Field | Meaning |
+|-------|---------|
+| `from: {source, source_port}` | Required source component and output port |
+| `to: target_port` | Required input port on the component being added |
+| `selector: path` | Optional safe path read after selecting the source port |
+| `target_path: path` | Optional safe path where the value is assembled within the target port |
+| `id: id` | Optional stable atom, string, or non-negative integer; otherwise generated deterministically |
+
+Paths are data-only lists of atom, string, or non-negative integer segments:
+
+```elixir
+payload = Runic.step(fn payload -> payload end,
+  name: :payload,
+  inputs: [request: [type: :any]]
+)
+
+workflow = Workflow.add(workflow, payload,
+  connections: [
+    [
+      id: "customer-id",
+      from: {:order, :payload},
+      to: :request,
+      selector: [:customer, :id],
+      target_path: [:customer_id]
+    ],
+    [
+      from: {:catalog, :item},
+      to: :request,
+      target_path: [:items, 0]
+    ]
+  ]
+)
+```
+
+The target's declared input-port order determines positional function arguments;
+connection declaration order does not. Every required target port must be bound,
+direct whole-port types must be compatible, and target paths for the same port
+must not overlap. A selector or target path changes the value shape, so Runic
+cannot infer its resulting type and leaves that routed value to runtime validation.
+
+### Step Invocation Convention
+
+The normal `Runic.step/2` API covers all supported call shapes; no invocation
+mode is selected by the author:
+
+```elixir
+Runic.step(fn -> :ready end)
+Runic.step(fn input -> normalize(input) end)
+
+Runic.step(fn left, right -> left + right end,
+  inputs: [left: [type: :integer], right: [type: :integer]]
+)
+
+Runic.step(fn request ->
+  call_service(request, context(:api_key))
+end)
+```
+
+Zero- and one-arity steps receive zero or one argument. Multi-arity steps receive
+positional values in declared input-port order. Runtime context is requested
+with `context/1`; an ordinary arity-two function is always a two-input function.
+
 ## Evaluating Workflows
 
 ### Basic Execution
@@ -450,6 +552,12 @@ Workflow.to_cytoscape(workflow)
 
 # Edge list
 Workflow.to_edgelist(workflow)
+
+# Authored components and logical :connects_to edges
+Workflow.component_graph(workflow)
+
+# Executable :flow/:fan_in graph, including generated bindings and joins
+Workflow.flow_graph(workflow)
 ```
 
 ## Common Patterns
@@ -513,6 +621,9 @@ Workflow.add(workflow, merge_step, to: [:a, :b, :c])
 | Create rule | `Runic.rule(fn x when guard -> result end)` |
 | Create workflow | `Runic.workflow(steps: [...], rules: [...])` |
 | Add component | `Workflow.add(workflow, component, to: parent)` |
+| Bind named ports | `Workflow.add(workflow, component, connections: [...])` |
+| Get authored graph | `Workflow.component_graph(workflow)` |
+| Get compiled flow graph | `Workflow.flow_graph(workflow)` |
 | Run one cycle | `Workflow.react(workflow, input)` |
 | Run to completion | `Workflow.react_until_satisfied(workflow, input)` |
 | Get structured results | `Workflow.results(workflow)` |

--- a/guides/usage-rules.md
+++ b/guides/usage-rules.md
@@ -70,6 +70,19 @@ Runic workflows are **data structures** (decorated directed acyclic graphs) that
 | **Parallel I/O-bound work** | `async: true` option | Uses `Task.async_stream` |
 | **Distributed execution** | `prepare_for_dispatch/1` | Extract runnables for remote execution |
 
+### Which Connection API to Use?
+
+| Intent | API | Why |
+|--------|-----|-----|
+| Pass one component's complete result to another | `Workflow.add(component, to: parent)` | Concise whole-value topology |
+| Wait for several complete parent results | `Workflow.add(component, to: parents)` | Creates the ordinary fan-in join |
+| Bind declared source and target ports | `Workflow.add(component, connections: specs)` | Durable, validated data contract |
+| Select part of a produced value | A connection with `selector: path` | Data-only projection, no executable edge callback |
+| Assemble a structured target input | Connections with `target_path: path` | Deterministic input construction |
+
+Do not pass both `:to` and `:connections`. A connection group describes the
+complete input assignment for the component being added.
+
 ### Three-Phase Execution APIs
 
 For custom schedulers, GenServers, or distributed execution:
@@ -235,6 +248,91 @@ else
 end
 ```
 
+### Prefer: Connections for Data Binding
+
+Keep ordinary Elixir responsible for building the workflow. Use connection data
+to describe how component outputs become component inputs:
+
+```elixir
+total = Runic.step(fn subtotal, tax -> subtotal + tax end,
+  name: :total,
+  inputs: [subtotal: [type: :money], tax: [type: :money]]
+)
+
+workflow =
+  workflow
+  |> Workflow.add(total,
+    connections: [
+      [from: {:pricing, :subtotal}, to: :subtotal],
+      [from: {:tax_service, :tax}, to: :tax]
+    ]
+  )
+```
+
+Avoid adding a `Runic.step/2` whose only job is to read and write a workflow-state
+map. That turns workflow construction into runtime domain work, hides the actual
+component relationship, and makes replay and graph inspection less precise.
+
+Connection groups are checked before graph mutation:
+
+- Source components and named ports must exist.
+- Every required target port must be bound.
+- Direct whole-port source and target types must be compatible unless either is `:any`.
+- Assignments to the same target port cannot overlap.
+- `selector` and `target_path` segments must be atoms, strings, or non-negative integers.
+
+Because a selector or target path changes the value shape, Runic cannot infer
+the resulting type statically and leaves that routed value to runtime validation.
+
+Use `validate: :warn` or `validate: :off` only for gradual prototyping. They
+relax type compatibility; they do not make invalid component references, ports,
+paths, or incomplete required inputs valid.
+
+### Declare Multi-Input Call Order Explicitly
+
+A multi-arity step's declared input-port order is its positional call order.
+Connection order is intentionally irrelevant:
+
+```elixir
+sum = Runic.step(fn left, right -> left + right end,
+  inputs: [left: [type: :integer], right: [type: :integer]]
+)
+```
+
+Use the documented `context/1` macro for runtime context. Do not add an implicit
+context positional argument; a plain arity-two step represents two domain inputs:
+
+```elixir
+# Two domain inputs
+Runic.step(fn request, options -> call(request, options) end,
+  inputs: [request: [type: :map], options: [type: :map]]
+)
+
+# One domain input plus runtime context
+Runic.step(fn request -> call(request, context(:api_key)) end,
+  inputs: [request: [type: :map]]
+)
+```
+
+### Inspect the Right Graph
+
+Named connections deliberately preserve two related views:
+
+```mermaid
+flowchart LR
+  A[Authored source] -->|connects_to with Connection data| B[Authored target]
+  A1[Source invokable] -->|flow| I[Generated InputBinding]
+  I -->|flow| B1[Target invokable]
+```
+
+- `Workflow.component_graph/1` returns authored components and logical
+  `:connects_to` relationships, including the durable connection descriptors.
+- `Workflow.flow_graph/1` returns executable `:flow` and `:fan_in` topology,
+  including generated input bindings and joins.
+
+Use these projections for topology inspection. Do not infer authored components
+from every scheduler-visible node in the full multigraph.
+
 ### Map-Reduce Pattern
 
 ```elixir
@@ -336,6 +434,10 @@ def load_workflow(id) do
 end
 ```
 
+Named connections are normalized into `%Runic.Workflow.Connection{}` data in
+the build log. A `build_log/1` and `from_log/1` round trip therefore rebuilds
+both the logical component connections and their compiled input-binding flow.
+
 ## Debugging Tips
 
 1. **Visualize with Mermaid**:
@@ -375,6 +477,8 @@ end
 | **Always require** | `require Runic` before macros |
 | **Always pin** | `^variable` for runtime values |
 | **Always name** | Components for debugging |
+| **Bind data with** | `connections:` for named ports, selectors, and target paths |
+| **Inspect topology with** | `component_graph/1` or `flow_graph/1`, depending on intent |
 | **Extract with** | `raw_productions/1`, not graph access |
 | **Serialize with** | `build_log/1` and `from_log/1` |
 | **Parallelize with** | `async: true` for I/O-bound work |

--- a/lib/exceptions/input_binding_error.ex
+++ b/lib/exceptions/input_binding_error.ex
@@ -1,0 +1,5 @@
+defmodule Runic.InputBindingError do
+  @moduledoc "Raised when a data-driven input binding cannot project or assemble a value."
+
+  defexception [:message, :connection, path: []]
+end

--- a/lib/runic.ex
+++ b/lib/runic.ex
@@ -162,7 +162,6 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: nil,
           outputs: nil,
-          invocation: :legacy,
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -186,7 +185,6 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: nil,
           outputs: nil,
-          invocation: :legacy,
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -214,8 +212,7 @@ defmodule Runic do
         hash: unquote(step_hash),
         work_hash: unquote(work_hash),
         inputs: nil,
-        outputs: nil,
-        invocation: :legacy
+        outputs: nil
       )
     end
   end
@@ -265,7 +262,6 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
-          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -295,7 +291,6 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
-          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -348,7 +343,6 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
-          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -378,7 +372,6 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
-          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end

--- a/lib/runic.ex
+++ b/lib/runic.ex
@@ -162,6 +162,7 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: nil,
           outputs: nil,
+          invocation: :legacy,
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -185,6 +186,7 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: nil,
           outputs: nil,
+          invocation: :legacy,
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -212,7 +214,8 @@ defmodule Runic do
         hash: unquote(step_hash),
         work_hash: unquote(work_hash),
         inputs: nil,
-        outputs: nil
+        outputs: nil,
+        invocation: :legacy
       )
     end
   end
@@ -262,6 +265,7 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
+          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -291,6 +295,7 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
+          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -343,6 +348,7 @@ defmodule Runic do
           work_hash: unquote(work_hash),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
+          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -372,6 +378,7 @@ defmodule Runic do
           work_hash: work_hash,
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
+          invocation: unquote(rewritten_opts[:invocation] || :legacy),
           meta_refs: unquote(escaped_meta_refs)
         )
       end

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -226,6 +226,8 @@ defmodule Runic.Workflow do
   alias Runic.Workflow.Join
   alias Runic.Workflow.Invokable
   alias Runic.Workflow.ComponentAdded
+  alias Runic.Workflow.Connection
+  alias Runic.Workflow.InputBinding
   alias Runic.Workflow.ComponentRemoved
   alias Runic.Workflow.ReactionOccurred
   alias Runic.Workflow.Runnable
@@ -625,8 +627,38 @@ defmodule Runic.Workflow do
 
   Untyped components (all ports default to `type: :any`) always pass validation,
   preserving Runic's gradual typing philosophy.
+
+  ## Named Port Connections
+
+  Use `:connections` when multiple producers supply distinct target inputs or
+  when a safe value path must be selected:
+
+      Workflow.add(workflow, score,
+        connections: [
+          [from: {:order_source, :order}, to: :order],
+          [from: {:customer_source, :customer}, to: :customer]
+        ]
+      )
+
+  `:connections` and `:to` are mutually exclusive. Connections are validated as
+  one target assignment, retained on logical `:connects_to` edges, and lowered
+  through an internal `InputBinding` plus the existing `Join` when necessary.
+  Generated binding nodes are linked with `:compiled_for`; they are not
+  registered as authored components.
+
+  A single declared source output port names the complete produced value. With
+  multiple declared outputs, the runtime value must expose the port by map or
+  keyword key, or by tuple/list position. `:selector` and `:target_path` accept
+  only atom, string, and non-negative integer path segments.
   """
   def add(%__MODULE__{} = workflow, component, opts \\ []) do
+    case Keyword.fetch(opts, :connections) do
+      {:ok, connections} -> add_with_connections(workflow, component, connections, opts)
+      :error -> add_to_parent(workflow, component, opts)
+    end
+  end
+
+  defp add_to_parent(%__MODULE__{} = workflow, component, opts) do
     case opts[:to] do
       nil ->
         # If no parent is specified, we assume the component is a root step
@@ -654,6 +686,321 @@ defmodule Runic.Workflow do
         parent_steps = Enum.map(parent_steps, &get_component!(workflow, &1))
 
         do_add_component(workflow, component, parent_steps, opts)
+    end
+  end
+
+  defp add_with_connections(workflow, component, connection_specs, opts) do
+    if Keyword.has_key?(opts, :to) do
+      raise ArgumentError, ":connections and :to are mutually exclusive"
+    end
+
+    component = ensure_component(component)
+    connections = Connection.normalize_all!(connection_specs, component)
+    resolved = Enum.map(connections, &resolve_connection!(workflow, &1))
+
+    validate_connection_group!(component, resolved, opts)
+    validate_bound_invocation!(component)
+
+    source_nodes =
+      resolved
+      |> Enum.map(& &1.source_node)
+      |> Enum.uniq_by(&Components.vertex_id_of/1)
+
+    source_order = Enum.map(source_nodes, &Components.vertex_id_of/1)
+
+    bindings =
+      Enum.map(resolved, fn resolved_connection ->
+        connection = resolved_connection.connection
+
+        %{
+          id: connection.id,
+          source_hash: Components.vertex_id_of(resolved_connection.source_node),
+          source_port: connection.source_port,
+          source_port_index: resolved_connection.source_port_index,
+          source_port_count: length(resolved_connection.source_outputs),
+          target_port: connection.target_port,
+          selector: connection.selector,
+          target_path: connection.target_path
+        }
+      end)
+
+    input_binding =
+      InputBinding.new(
+        target_component_hash: Component.hash(component),
+        source_order: source_order,
+        bindings: bindings,
+        input_ports: Component.inputs(component)
+      )
+
+    {workflow, binding_parent} = connect_binding_sources(workflow, source_nodes)
+
+    workflow =
+      workflow
+      |> add_step(binding_parent, input_binding)
+      |> then(&Component.connect(component, input_binding, &1))
+      |> draw_connection(component, input_binding, :compiled_for,
+        properties: %{
+          kind: :input_binding,
+          connection_ids: Enum.map(connections, & &1.id)
+        }
+      )
+      |> draw_logical_connections(component, resolved)
+
+    if Keyword.get(opts, :log, true) do
+      append_build_log(workflow, build_events(component, nil, connections))
+    else
+      workflow
+    end
+  end
+
+  defp ensure_component(%{__struct__: _} = component) do
+    if Components.component?(component), do: component, else: transmute_component!(component)
+  end
+
+  defp ensure_component(component), do: transmute_component!(component)
+
+  defp resolve_connection!(workflow, %Connection{} = connection) do
+    source_component = resolve_component_ref!(workflow, connection.source)
+    source_outputs = Component.outputs(source_component)
+
+    source_port_index =
+      Enum.find_index(source_outputs, fn {port_name, _schema} ->
+        port_name == connection.source_port
+      end)
+
+    if is_nil(source_port_index) do
+      raise ArgumentError,
+            "component #{inspect(component_name(source_component))} has no output port #{inspect(connection.source_port)}"
+    end
+
+    %{
+      connection: connection,
+      source_component: source_component,
+      source_node: output_node!(workflow, source_component),
+      source_outputs: source_outputs,
+      source_port_index: source_port_index
+    }
+  end
+
+  defp resolve_component_ref!(_workflow, %{__struct__: _} = component), do: component
+
+  defp resolve_component_ref!(workflow, hash) when is_integer(hash) do
+    case get_by_hash(workflow, hash) do
+      nil -> raise KeyError, message: "No component found with hash #{inspect(hash)}"
+      component -> component
+    end
+  end
+
+  defp resolve_component_ref!(workflow, {name, kind}) do
+    workflow
+    |> get_component!({name, kind})
+    |> List.first()
+  end
+
+  defp resolve_component_ref!(workflow, name), do: get_component!(workflow, name)
+
+  defp output_node!(workflow, %Rule{} = rule) do
+    Map.fetch!(workflow.graph.vertices, rule.reaction_hash)
+  end
+
+  defp output_node!(workflow, %Runic.Workflow.Map{name: name}) do
+    case get_component!(workflow, {name, :leaf}) do
+      [leaf] ->
+        leaf
+
+      leaves ->
+        raise ArgumentError,
+              "map #{inspect(name)} has #{length(leaves)} leaf nodes; its output port cannot be lowered unambiguously"
+    end
+  end
+
+  defp output_node!(_workflow, %Runic.Workflow.Reduce{fan_in: fan_in}), do: fan_in
+
+  defp output_node!(workflow, component) do
+    if Components.invokable?(component) do
+      component
+    else
+      output_node_from_ownership!(workflow, component)
+    end
+  end
+
+  defp output_node_from_ownership!(workflow, component) do
+    preferred_kinds = [:reaction, :leaf, :fan_in, :accumulator, :step]
+
+    edges =
+      workflow.graph
+      |> Multigraph.out_edges(component, by: :component_of)
+      |> Enum.sort_by(fn edge ->
+        Enum.find_index(preferred_kinds, &(&1 == edge.properties[:kind])) ||
+          length(preferred_kinds)
+      end)
+
+    case edges do
+      [%{v2: node}] ->
+        node
+
+      [] ->
+        raise ArgumentError,
+              "cannot determine output node for #{inspect(component_name(component))}"
+
+      [%{v2: node} = first | rest] ->
+        kind = first.properties[:kind]
+
+        if Enum.any?(rest, &(&1.properties[:kind] == kind)) do
+          raise ArgumentError,
+                "component #{inspect(component_name(component))} has multiple #{inspect(kind)} output nodes"
+        else
+          node
+        end
+    end
+  end
+
+  defp connect_binding_sources(workflow, [source_node]), do: {workflow, source_node}
+
+  defp connect_binding_sources(workflow, source_nodes) do
+    join = source_nodes |> Enum.map(&Components.vertex_id_of/1) |> Join.new()
+    {add_step(workflow, source_nodes, join), join}
+  end
+
+  defp draw_logical_connections(workflow, component, resolved) do
+    resolved
+    |> Enum.group_by(&Component.hash(&1.source_component))
+    |> Enum.reduce(workflow, fn {_source_hash, source_connections}, wrk ->
+      source_component = source_connections |> List.first() |> Map.fetch!(:source_component)
+      connections = Enum.map(source_connections, & &1.connection)
+
+      draw_connection(wrk, source_component, component, :connects_to,
+        properties: %{kind: :port_binding, connections: connections}
+      )
+    end)
+  end
+
+  defp validate_connection_group!(component, resolved, opts) do
+    inputs = Component.inputs(component)
+
+    Enum.each(resolved, fn %{connection: connection, source_component: producer} ->
+      target_schema = Keyword.get(inputs, connection.target_port)
+
+      if is_nil(target_schema) do
+        raise ArgumentError,
+              "component #{inspect(component_name(component))} has no input port #{inspect(connection.target_port)}"
+      end
+
+      source_schema = Keyword.fetch!(Component.outputs(producer), connection.source_port)
+
+      validate_connection_types!(
+        producer,
+        component,
+        source_schema,
+        target_schema,
+        connection,
+        opts
+      )
+    end)
+
+    assigned_ports = resolved |> Enum.map(& &1.connection.target_port) |> MapSet.new()
+
+    missing_ports =
+      inputs
+      |> Enum.filter(fn {_port, schema} -> Keyword.get(schema, :required, true) end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.reject(&MapSet.member?(assigned_ports, &1))
+
+    if missing_ports != [] do
+      raise ArgumentError,
+            "component #{inspect(component_name(component))} has unassigned required input ports: #{inspect(missing_ports)}"
+    end
+
+    validate_target_paths!(resolved)
+  end
+
+  defp validate_target_paths!(resolved) do
+    resolved
+    |> Enum.group_by(& &1.connection.target_port)
+    |> Enum.each(fn {port, port_connections} ->
+      indexed_connections = Enum.with_index(port_connections)
+
+      for {left, left_index} <- indexed_connections,
+          {right, right_index} <- indexed_connections,
+          left_index < right_index,
+          paths_overlap?(left.connection.target_path, right.connection.target_path) do
+        raise ArgumentError,
+              "target port #{inspect(port)} has overlapping assignments at #{inspect(left.connection.target_path)} and #{inspect(right.connection.target_path)}"
+      end
+    end)
+  end
+
+  defp paths_overlap?([], _path), do: true
+  defp paths_overlap?(_path, []), do: true
+
+  defp paths_overlap?(left, right) do
+    prefix_length = min(length(left), length(right))
+    Enum.take(left, prefix_length) == Enum.take(right, prefix_length)
+  end
+
+  defp validate_connection_types!(
+         producer,
+         consumer,
+         source_schema,
+         target_schema,
+         connection,
+         opts
+       ) do
+    validation = Keyword.get(opts, :validate, :error)
+    producer_type = Keyword.get(source_schema, :type, :any)
+    consumer_type = Keyword.get(target_schema, :type, :any)
+
+    routed? = connection.selector != [] or connection.target_path != []
+
+    compatible? =
+      routed? or Component.TypeCompatibility.types_compatible?(producer_type, consumer_type)
+
+    case {validation, compatible?} do
+      {:off, _} ->
+        :ok
+
+      {_, true} ->
+        :ok
+
+      {:warn, false} ->
+        Logger.warning(
+          "Port incompatibility connecting #{inspect(component_name(consumer))}.#{connection.target_port} to #{inspect(component_name(producer))}.#{connection.source_port}: #{inspect({producer_type, consumer_type})}"
+        )
+
+      {:error, false} ->
+        raise Runic.IncompatiblePortError,
+          producer: producer,
+          consumer: consumer,
+          reasons: [{:type_mismatch, producer_type, consumer_type}]
+    end
+  end
+
+  defp validate_bound_invocation!(%Step{} = step) do
+    input_count = length(Component.inputs(step))
+    arity = Components.arity_of(step.work)
+
+    case {input_count, step.invocation} do
+      {count, :legacy} when count > 1 ->
+        raise ArgumentError,
+              "port-bound step #{inspect(step.name)} has multiple inputs; declare invocation: :positional_inputs"
+
+      {count, :positional_inputs} when count != arity ->
+        raise ArgumentError,
+              "port-bound step #{inspect(step.name)} declares #{count} inputs but its positional work function has arity #{arity}"
+
+      {count, :input_and_context} when count != 1 or arity != 2 ->
+        raise ArgumentError,
+              "port-bound step #{inspect(step.name)} using :input_and_context must declare one input and use an arity-2 work function"
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp validate_bound_invocation!(component) do
+    if length(Component.inputs(component)) > 1 do
+      raise ArgumentError,
+            "multi-port lowering is currently supported only for Runic steps with invocation: :positional_inputs"
     end
   end
 
@@ -806,7 +1153,14 @@ defmodule Runic.Workflow do
   """
   def add_with_events(%__MODULE__{} = workflow, component, opts \\ []) do
     to = opts[:to]
-    events = build_events(component, to)
+
+    connections =
+      case Keyword.fetch(opts, :connections) do
+        {:ok, connection_specs} -> Connection.normalize_all!(connection_specs, component)
+        :error -> nil
+      end
+
+    events = build_events(component, to, connections)
 
     workflow =
       workflow
@@ -816,7 +1170,7 @@ defmodule Runic.Workflow do
     {workflow, events}
   end
 
-  defp build_events(component, parent) do
+  defp build_events(component, parent, connections) do
     closure = Map.get(component, :closure)
 
     [
@@ -824,6 +1178,7 @@ defmodule Runic.Workflow do
         closure: closure,
         name: component.name,
         to: durable_parent_ref(parent),
+        connections: connections,
         hash: Map.get(component, :hash),
         # Backward compatibility: also set source/bindings for old deserialization
         source: Component.source(component),
@@ -920,7 +1275,7 @@ defmodule Runic.Workflow do
   def apply_event(%__MODULE__{} = wrk, %ComponentAdded{} = event) do
     component = component_from_added(event)
 
-    add(wrk, component, to: event.to)
+    add_component_event(wrk, component, event)
   end
 
   def apply_event(%__MODULE__{} = wf, %FactProduced{} = e) do
@@ -1185,6 +1540,7 @@ defmodule Runic.Workflow do
 
   defp legacy_group_member?(%ComponentAdded{} = previous, %ComponentAdded{} = event) do
     not is_nil(previous.to) and not is_nil(event.to) and
+      is_nil(Map.get(previous, :connections)) and is_nil(Map.get(event, :connections)) and
       component_event_identity(previous) == component_event_identity(event) and
       event.to not in List.wrap(previous.to)
   end
@@ -1195,6 +1551,16 @@ defmodule Runic.Workflow do
     do: {:hash, hash}
 
   defp component_event_identity(%ComponentAdded{name: name}), do: {:name, name}
+
+  defp add_component_event(workflow, component, %ComponentAdded{} = event) do
+    case Map.get(event, :connections) do
+      connections when is_list(connections) and connections != [] ->
+        add(workflow, component, connections: connections)
+
+      _ ->
+        add(workflow, component, to: event.to)
+    end
+  end
 
   defp component_from_added(
          %ComponentAdded{source: source, bindings: bindings, closure: closure} = event
@@ -1292,8 +1658,7 @@ defmodule Runic.Workflow do
       %ComponentAdded{} = event, wrk ->
         component = component_from_added(event)
 
-        # Add the component to the workflow
-        add(wrk, component, to: event.to)
+        add_component_event(wrk, component, event)
 
       %ReactionOccurred{reaction: :generation}, wrk ->
         # Skip legacy generation edges - generation counters removed
@@ -1567,16 +1932,56 @@ defmodule Runic.Workflow do
 
     component_edges = Multigraph.edges(g, by: :connects_to)
 
-    Enum.reduce(component_edges, Multigraph.new(type: :directed), fn edge, cg ->
+    projected_graph =
+      Multigraph.new(
+        type: :directed,
+        multigraph: true,
+        vertex_identifier: &Components.vertex_id_of/1
+      )
+
+    Enum.reduce(component_edges, projected_graph, fn %Multigraph.Edge{} = edge, cg ->
       v1 = Map.get(component_vertices, edge.v1.hash, edge.v1)
       v2 = Map.get(component_vertices, edge.v2.hash, edge.v2)
-      Multigraph.add_edge(cg, v1, v2, label: :connects_to)
+      Multigraph.add_edge(cg, %Multigraph.Edge{edge | v1: v1, v2: v2})
     end)
     |> then(fn cg ->
       # Ensure all registered components appear as vertices, even if unconnected
       Enum.reduce(component_vertices, cg, fn {_hash, vertex}, acc ->
         if vertex, do: Multigraph.add_vertex(acc, vertex), else: acc
       end)
+    end)
+  end
+
+  @doc """
+  Returns the authored component graph.
+
+  This is the preferred name for `connected_components/1`. Logical
+  `:connects_to` edge properties, including named port connections, are
+  preserved in the projection.
+  """
+  @spec component_graph(t()) :: Multigraph.t()
+  def component_graph(%__MODULE__{} = workflow), do: connected_components(workflow)
+
+  @doc """
+  Returns the compiled executable graph containing `:flow` and `:fan_in` edges.
+
+  Authored `:connects_to` declarations and runtime fact history are excluded.
+  Generated `InputBinding` and `Join` nodes remain visible because they are
+  scheduler-visible invokables.
+  """
+  @spec flow_graph(t()) :: Multigraph.t()
+  def flow_graph(%__MODULE__{graph: graph}) do
+    projected_graph =
+      Multigraph.new(
+        type: :directed,
+        multigraph: true,
+        vertex_identifier: &Components.vertex_id_of/1
+      )
+
+    graph
+    |> Multigraph.edges(by: [:flow, :fan_in])
+    |> Enum.reduce(projected_graph, fn edge, projected ->
+      Multigraph.add_edge(projected, edge)
     end)
   end
 

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -136,6 +136,15 @@ defmodule Runic.Workflow do
 
   Any component implementing the `Runic.Transmutable` protocol can be merged into a workflow.
 
+  Use `add/3` with `:to` for ordinary whole-value topology. Use its
+  `:connections` option when source ports, target ports, safe projections, or
+  structured target assembly are part of the authored contract. Connections
+  remain on logical `:connects_to` edges while Runic lowers them into executable
+  input-binding flow.
+
+  Use `component_graph/1` to inspect authored relationships and `flow_graph/1`
+  to inspect scheduler-visible `:flow` and `:fan_in` topology.
+
   ## Introspection APIs
 
   Query workflow structure and state:
@@ -641,6 +650,15 @@ defmodule Runic.Workflow do
         ]
       )
 
+  Each connection accepts:
+
+  - `:from` — required `{source_component, source_port}`; alternatively pass a
+    source component and a separate `:source_port`
+  - `:to` — required target input port on the component being added
+  - `:selector` — optional safe path read from the selected source value
+  - `:target_path` — optional safe path assembled within the target port
+  - `:id` — optional stable atom, string, or non-negative integer
+
   `:connections` and `:to` are mutually exclusive. Connections are validated as
   one target assignment, retained on logical `:connects_to` edges, and lowered
   through an internal `InputBinding` plus the existing `Join` when necessary.
@@ -651,6 +669,16 @@ defmodule Runic.Workflow do
   multiple declared outputs, the runtime value must expose the port by map or
   keyword key, or by tuple/list position. `:selector` and `:target_path` accept
   only atom, string, and non-negative integer path segments.
+
+  Multi-arity Steps receive bound values in declared input-port order, not
+  connection declaration order. Required ports must all be bound and multiple
+  assignments within one target port must use non-overlapping target paths.
+  Direct whole-port bindings are type-checked; selectors and target paths change
+  value shape, so their resulting values are left to runtime validation.
+
+  See `Runic.Workflow.Connection`, the
+  [Cheatsheet](cheatsheet.html#named-port-connections), and the
+  [Usage Rules](usage-rules.html#prefer-connections-for-data-binding).
   """
   def add(%__MODULE__{} = workflow, component, opts \\ []) do
     case Keyword.fetch(opts, :connections) do

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -228,6 +228,7 @@ defmodule Runic.Workflow do
   alias Runic.Workflow.ComponentAdded
   alias Runic.Workflow.Connection
   alias Runic.Workflow.InputBinding
+  alias Runic.Workflow.CallContract
   alias Runic.Workflow.ComponentRemoved
   alias Runic.Workflow.ReactionOccurred
   alias Runic.Workflow.Runnable
@@ -699,7 +700,7 @@ defmodule Runic.Workflow do
     resolved = Enum.map(connections, &resolve_connection!(workflow, &1))
 
     validate_connection_group!(component, resolved, opts)
-    validate_bound_invocation!(component)
+    validate_bound_call_contract!(component)
 
     source_nodes =
       resolved
@@ -975,32 +976,36 @@ defmodule Runic.Workflow do
     end
   end
 
-  defp validate_bound_invocation!(%Step{} = step) do
+  defp validate_bound_call_contract!(%Step{} = step) do
     input_count = length(Component.inputs(step))
-    arity = Components.arity_of(step.work)
+    contract = CallContract.for_step(step)
 
-    case {input_count, step.invocation} do
-      {count, :legacy} when count > 1 ->
+    case contract.style do
+      :zero_arity when input_count != 0 ->
         raise ArgumentError,
-              "port-bound step #{inspect(step.name)} has multiple inputs; declare invocation: :positional_inputs"
+              "port-bound zero-arity step #{inspect(step.name)} cannot declare input ports"
 
-      {count, :positional_inputs} when count != arity ->
+      :single_input when input_count != 1 ->
         raise ArgumentError,
-              "port-bound step #{inspect(step.name)} declares #{count} inputs but its positional work function has arity #{arity}"
+              "port-bound step #{inspect(step.name)} declares #{input_count} inputs but its work function accepts one input"
 
-      {count, :input_and_context} when count != 1 or arity != 2 ->
+      :positional when input_count != contract.authored_arity ->
         raise ArgumentError,
-              "port-bound step #{inspect(step.name)} using :input_and_context must declare one input and use an arity-2 work function"
+              "port-bound step #{inspect(step.name)} declares #{input_count} inputs but its work function accepts #{contract.authored_arity} positional inputs"
+
+      :input_and_context when input_count != 1 or contract.compiled_arity != 2 ->
+        raise ArgumentError,
+              "context-bound step #{inspect(step.name)} must declare one input and compile to an arity-2 work function"
 
       _ ->
         :ok
     end
   end
 
-  defp validate_bound_invocation!(component) do
+  defp validate_bound_call_contract!(component) do
     if length(Component.inputs(component)) > 1 do
       raise ArgumentError,
-            "multi-port lowering is currently supported only for Runic steps with invocation: :positional_inputs"
+            "multi-port lowering is currently supported only for Runic steps"
     end
   end
 

--- a/lib/workflow/call_contract.ex
+++ b/lib/workflow/call_contract.ex
@@ -1,0 +1,164 @@
+defmodule Runic.Workflow.CallContract do
+  @moduledoc false
+
+  alias Runic.Workflow.Components
+
+  @version 1
+  @styles [:zero_arity, :single_input, :positional, :input_and_context]
+
+  @type style :: :zero_arity | :single_input | :positional | :input_and_context
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          style: style(),
+          authored_arity: non_neg_integer(),
+          compiled_arity: non_neg_integer(),
+          input_order: list(atom() | non_neg_integer()),
+          binding_refs: list(map())
+        }
+
+  @enforce_keys [:version, :style, :authored_arity, :compiled_arity, :input_order]
+  defstruct [
+    :version,
+    :style,
+    :authored_arity,
+    :compiled_arity,
+    :input_order,
+    binding_refs: []
+  ]
+
+  @doc false
+  @spec compile(map()) :: t()
+  def compile(step) when is_map(step) do
+    work = Map.fetch!(step, :work)
+    compiled_arity = Components.arity_of(work)
+    meta_refs = Map.get(step, :meta_refs, [])
+    contextual? = meta_refs != []
+    authored_arity = if contextual?, do: max(compiled_arity - 1, 0), else: compiled_arity
+
+    style =
+      cond do
+        contextual? -> :input_and_context
+        authored_arity == 0 -> :zero_arity
+        authored_arity == 1 -> :single_input
+        true -> :positional
+      end
+
+    %__MODULE__{
+      version: @version,
+      style: style,
+      authored_arity: authored_arity,
+      compiled_arity: compiled_arity,
+      input_order: input_order(Map.get(step, :inputs), authored_arity),
+      binding_refs: normalize_binding_refs(meta_refs)
+    }
+    |> validate!()
+  end
+
+  @doc false
+  @spec for_step(map()) :: t()
+  def for_step(step) when is_map(step) do
+    case Map.get(step, :call_contract) do
+      %__MODULE__{} = contract -> validate!(contract)
+      nil -> compile(step)
+      contract -> raise ArgumentError, "invalid step call contract: #{inspect(contract)}"
+    end
+  end
+
+  @doc false
+  @spec validate!(t()) :: t()
+  def validate!(%__MODULE__{} = contract) do
+    unless contract.version == @version do
+      raise ArgumentError,
+            "unsupported call contract version #{inspect(contract.version)}; expected #{@version}"
+    end
+
+    unless contract.style in @styles do
+      raise ArgumentError, "unsupported call contract style: #{inspect(contract.style)}"
+    end
+
+    unless is_integer(contract.authored_arity) and contract.authored_arity >= 0 and
+             is_integer(contract.compiled_arity) and contract.compiled_arity >= 0 do
+      raise ArgumentError, "call contract arities must be non-negative integers"
+    end
+
+    unless is_list(contract.input_order) and
+             Enum.all?(contract.input_order, &(is_atom(&1) or (is_integer(&1) and &1 >= 0))) do
+      raise ArgumentError,
+            "call contract input order must contain atom port names or positional indexes"
+    end
+
+    unless is_list(contract.binding_refs) and Enum.all?(contract.binding_refs, &is_map/1) do
+      raise ArgumentError, "call contract binding refs must be data maps"
+    end
+
+    validate_style_shape!(contract)
+
+    contract
+  end
+
+  defp validate_style_shape!(%__MODULE__{
+         style: :zero_arity,
+         authored_arity: 0,
+         compiled_arity: 0
+       }),
+       do: :ok
+
+  defp validate_style_shape!(%__MODULE__{
+         style: :single_input,
+         authored_arity: 1,
+         compiled_arity: 1
+       }),
+       do: :ok
+
+  defp validate_style_shape!(%__MODULE__{
+         style: :positional,
+         authored_arity: arity,
+         compiled_arity: arity
+       })
+       when arity > 1,
+       do: :ok
+
+  defp validate_style_shape!(%__MODULE__{
+         style: :input_and_context,
+         authored_arity: 1,
+         compiled_arity: 2
+       }),
+       do: :ok
+
+  defp validate_style_shape!(contract) do
+    raise ArgumentError,
+          "call contract style #{inspect(contract.style)} is inconsistent with authored arity #{contract.authored_arity} and compiled arity #{contract.compiled_arity}"
+  end
+
+  defp input_order(_inputs, 0), do: []
+
+  defp input_order(nil, 1), do: [:in]
+
+  defp input_order(nil, arity) do
+    Enum.to_list(0..(arity - 1))
+  end
+
+  defp input_order(inputs, _arity) when is_list(inputs) do
+    cond do
+      Keyword.keyword?(inputs) -> Keyword.keys(inputs)
+      Enum.all?(inputs, &is_atom/1) -> inputs
+      true -> raise ArgumentError, "step inputs must contain named ports, got: #{inspect(inputs)}"
+    end
+  end
+
+  defp input_order(inputs, _arity) do
+    raise ArgumentError, "step inputs must be a keyword list, got: #{inspect(inputs)}"
+  end
+
+  defp normalize_binding_refs(meta_refs) do
+    Enum.map(meta_refs, fn ref ->
+      %{
+        kind: Map.fetch!(ref, :kind),
+        target: Map.get(ref, :target),
+        context_key: Map.get(ref, :context_key),
+        field_path: Map.get(ref, :field_path, [])
+      }
+    end)
+  end
+end

--- a/lib/workflow/component_added.ex
+++ b/lib/workflow/component_added.ex
@@ -13,6 +13,7 @@ defmodule Runic.Workflow.ComponentAdded do
           source: term() | nil,
           bindings: map(),
           to: term(),
+          connections: list(Runic.Workflow.Connection.t()) | nil,
           hash: term()
         }
 
@@ -23,6 +24,7 @@ defmodule Runic.Workflow.ComponentAdded do
     :source,
     :bindings,
     :to,
+    :connections,
     :hash
   ]
 

--- a/lib/workflow/connection.ex
+++ b/lib/workflow/connection.ex
@@ -1,0 +1,153 @@
+defmodule Runic.Workflow.Connection do
+  @moduledoc """
+  A durable named-port connection between two workflow components.
+
+  Connections describe authored intent. `Runic.Workflow.add/3` validates a
+  complete connection group and lowers it into executable flow nodes. The
+  connection itself remains data and is stored on logical `:connects_to` edges
+  and in `%Runic.Workflow.ComponentAdded{}` events.
+
+  The compact keyword form accepted by `Runic.Workflow.add/3` is normalized
+  into this struct:
+
+      [from: {:orders, :order}, to: :order]
+
+  Safe `:selector` and `:target_path` lists may contain atom, string, or
+  non-negative integer segments. They never contain executable functions.
+  """
+
+  alias Runic.Workflow.Components
+
+  @type component_ref :: atom() | String.t() | non_neg_integer() | {atom() | String.t(), atom()}
+  @type port_name :: atom()
+  @type path_segment :: atom() | String.t() | non_neg_integer()
+  @type connection_id :: atom() | String.t() | non_neg_integer()
+
+  @type t :: %__MODULE__{
+          id: connection_id(),
+          source: component_ref(),
+          source_port: port_name(),
+          target: component_ref(),
+          target_port: port_name(),
+          selector: list(path_segment()),
+          target_path: list(path_segment())
+        }
+
+  @enforce_keys [:id, :source, :source_port, :target, :target_port]
+  defstruct [:id, :source, :source_port, :target, :target_port, selector: [], target_path: []]
+
+  @doc false
+  @spec normalize_all!(list(), struct()) :: [t()]
+  def normalize_all!(connections, target) when is_list(connections) and connections != [] do
+    target_ref = durable_ref(target)
+
+    Enum.map(connections, &normalize!(&1, target_ref))
+  end
+
+  def normalize_all!(connections, _target) do
+    raise ArgumentError,
+          ":connections must be a non-empty list, got: #{inspect(connections)}"
+  end
+
+  @doc false
+  @spec normalize!(t() | map() | keyword(), component_ref()) :: t()
+  def normalize!(%__MODULE__{target: target} = connection, target),
+    do: validate_connection!(connection)
+
+  def normalize!(%__MODULE__{target: connection_target}, target) do
+    raise ArgumentError,
+          "connection targets #{inspect(connection_target)}, but it was supplied while adding #{inspect(target)}"
+  end
+
+  def normalize!(connection, target) when is_list(connection) or is_map(connection) do
+    spec = if is_list(connection), do: Map.new(connection), else: connection
+    {source, source_port} = normalize_source!(fetch!(spec, :from), spec)
+    target_port = Map.get(spec, :to) || Map.get(spec, :target_port)
+
+    selector = normalize_path!(Map.get(spec, :selector, []), :selector)
+    target_path = normalize_path!(Map.get(spec, :target_path, []), :target_path)
+    source = durable_ref(source)
+
+    id =
+      Map.get(spec, :id) ||
+        Components.fact_hash({source, source_port, target, target_port, selector, target_path})
+
+    validate_connection!(%__MODULE__{
+      id: id,
+      source: source,
+      source_port: source_port,
+      target: target,
+      target_port: target_port,
+      selector: selector,
+      target_path: target_path
+    })
+  end
+
+  def normalize!(connection, _target) do
+    raise ArgumentError,
+          "connection must be a keyword list, map, or Connection struct, got: #{inspect(connection)}"
+  end
+
+  defp normalize_source!({source, source_port}, _spec), do: {source, source_port}
+
+  defp normalize_source!(source, spec) do
+    case Map.get(spec, :source_port) do
+      nil ->
+        raise ArgumentError,
+              "connection from #{inspect(source)} must declare :source_port or use from: {source, port}"
+
+      source_port ->
+        {source, source_port}
+    end
+  end
+
+  defp normalize_path!(path, _field) when is_list(path) do
+    if Enum.all?(path, &path_segment?/1) do
+      path
+    else
+      raise ArgumentError,
+            "connection paths support only atom, string, and non-negative integer segments"
+    end
+  end
+
+  defp normalize_path!(path, field) do
+    raise ArgumentError, "connection #{field} must be a list, got: #{inspect(path)}"
+  end
+
+  defp path_segment?(segment),
+    do: is_atom(segment) or is_binary(segment) or (is_integer(segment) and segment >= 0)
+
+  defp validate_connection!(%__MODULE__{} = connection) do
+    unless is_atom(connection.source_port) do
+      raise ArgumentError,
+            "source port must be an atom, got: #{inspect(connection.source_port)}"
+    end
+
+    unless is_atom(connection.target_port) do
+      raise ArgumentError,
+            "target port must be an atom, got: #{inspect(connection.target_port)}"
+    end
+
+    normalize_path!(connection.selector, :selector)
+    normalize_path!(connection.target_path, :target_path)
+
+    unless is_atom(connection.id) or is_binary(connection.id) or
+             (is_integer(connection.id) and connection.id >= 0) do
+      raise ArgumentError,
+            "connection id must be an atom, string, or non-negative integer, got: #{inspect(connection.id)}"
+    end
+
+    connection
+  end
+
+  defp fetch!(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> raise ArgumentError, "connection is missing required #{inspect(key)}"
+    end
+  end
+
+  defp durable_ref(%{name: name}) when not is_nil(name), do: name
+  defp durable_ref(%{hash: hash}) when not is_nil(hash), do: hash
+  defp durable_ref(reference), do: reference
+end

--- a/lib/workflow/connection.ex
+++ b/lib/workflow/connection.ex
@@ -8,12 +8,44 @@ defmodule Runic.Workflow.Connection do
   and in `%Runic.Workflow.ComponentAdded{}` events.
 
   The compact keyword form accepted by `Runic.Workflow.add/3` is normalized
-  into this struct:
+  into this struct. The component being added supplies the target component:
 
       [from: {:orders, :order}, to: :order]
 
+  `:from` identifies `{source_component, source_port}` and `:to` identifies the
+  target input port. The long source form is also accepted:
+
+      [from: :orders, source_port: :order, to: :order]
+
+  ## Projection and assembly
+
+  `:selector` reads a path from the selected source value. `:target_path`
+  places that value inside a structure assembled for the target port:
+
+      [
+        id: "customer-id",
+        from: {:orders, :payload},
+        to: :request,
+        selector: [:customer, :id],
+        target_path: [:customer_id]
+      ]
+
+  A source with one declared output treats that port as the complete produced
+  value. A source with several outputs exposes values by map or keyword key, or
+  by tuple/list position. The target's declared input-port order, not connection
+  declaration order, determines positional arguments for multi-arity steps.
+
   Safe `:selector` and `:target_path` lists may contain atom, string, or
   non-negative integer segments. They never contain executable functions.
+  Target paths assigned within one connection group must not overlap.
+
+  `:id` is optional in the keyword form. If omitted, Runic derives a stable ID
+  from the normalized connection data. Authored IDs may be atoms, strings, or
+  non-negative integers.
+
+  See the [Cheatsheet](cheatsheet.html#named-port-connections) and
+  [Usage Rules](usage-rules.html#prefer-connections-for-data-binding) for full
+  construction examples and API-selection guidance.
   """
 
   alias Runic.Workflow.Components

--- a/lib/workflow/input_binding.ex
+++ b/lib/workflow/input_binding.ex
@@ -77,6 +77,24 @@ defmodule Runic.Workflow.InputBinding do
     end
   end
 
+  @doc false
+  @spec fact_meta(t()) :: map()
+  def fact_meta(%__MODULE__{} = binding) do
+    sources =
+      Enum.map(binding.bindings, fn source_binding ->
+        Map.take(source_binding, [
+          :id,
+          :source_hash,
+          :source_port,
+          :target_port,
+          :selector,
+          :target_path
+        ])
+      end)
+
+    %{runic: %{input_bindings: sources}}
+  end
+
   defp source_values([source_hash], input), do: %{source_hash => input}
 
   defp source_values(source_order, input) when is_list(input) do

--- a/lib/workflow/input_binding.ex
+++ b/lib/workflow/input_binding.ex
@@ -1,0 +1,230 @@
+defmodule Runic.Workflow.InputBinding do
+  @moduledoc """
+  Internal, serializable lowering node for named component-port connections.
+
+  An input binding projects safe paths from ordinary domain values and assembles
+  the target's declared input shape. It is an invokable compiler artifact, not
+  a registered user-authored component.
+  """
+
+  alias Runic.Workflow.Components
+
+  @type binding :: %{
+          id: Runic.Workflow.Connection.connection_id(),
+          source_hash: term(),
+          source_port: atom(),
+          source_port_index: non_neg_integer(),
+          source_port_count: pos_integer(),
+          target_port: atom(),
+          selector: list(),
+          target_path: list()
+        }
+
+  @type t :: %__MODULE__{
+          hash: non_neg_integer(),
+          target_component_hash: term(),
+          source_order: list(term()),
+          bindings: list(binding()),
+          input_ports: keyword()
+        }
+
+  @enforce_keys [:hash, :target_component_hash, :source_order, :bindings, :input_ports]
+  defstruct [:hash, :target_component_hash, :source_order, :bindings, :input_ports]
+
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    target_component_hash = Keyword.fetch!(opts, :target_component_hash)
+    source_order = Keyword.fetch!(opts, :source_order)
+    bindings = Keyword.fetch!(opts, :bindings)
+    input_ports = Keyword.fetch!(opts, :input_ports)
+
+    hash =
+      Components.fact_hash(
+        {__MODULE__, target_component_hash, source_order, bindings, input_ports}
+      )
+
+    %__MODULE__{
+      hash: hash,
+      target_component_hash: target_component_hash,
+      source_order: source_order,
+      bindings: bindings,
+      input_ports: input_ports
+    }
+  end
+
+  @spec bind(t(), term()) :: term()
+  def bind(%__MODULE__{} = binding, input) do
+    source_values = source_values(binding.source_order, input)
+
+    values_by_port =
+      Enum.reduce(binding.bindings, %{}, fn connection, acc ->
+        source_value = Map.fetch!(source_values, connection.source_hash)
+
+        value =
+          source_value
+          |> project_port(connection)
+          |> select_path(connection.selector, connection)
+
+        put_target_value(acc, connection.target_port, connection.target_path, value, connection)
+      end)
+
+    ordered_values =
+      Enum.map(binding.input_ports, fn {port, _schema} -> Map.get(values_by_port, port) end)
+
+    case ordered_values do
+      [value] -> value
+      values -> values
+    end
+  end
+
+  defp source_values([source_hash], input), do: %{source_hash => input}
+
+  defp source_values(source_order, input) when is_list(input) do
+    if length(source_order) == length(input) do
+      Map.new(Enum.zip(source_order, input))
+    else
+      binding_error!(
+        "input binding expected #{length(source_order)} joined values, got #{length(input)}",
+        nil,
+        []
+      )
+    end
+  end
+
+  defp source_values(source_order, input) do
+    binding_error!(
+      "input binding expected joined values for #{length(source_order)} sources, got: #{inspect(input)}",
+      nil,
+      []
+    )
+  end
+
+  defp project_port(value, %{source_port_count: 1}), do: value
+
+  defp project_port(value, connection) do
+    fetch_segment(value, connection.source_port, connection.source_port_index, connection)
+  end
+
+  defp select_path(value, path, connection) do
+    Enum.reduce(path, value, fn segment, current ->
+      fetch_segment(current, segment, segment, connection)
+    end)
+  end
+
+  defp fetch_segment(value, segment, _position, connection) when is_map(value) do
+    selected =
+      case Map.fetch(value, segment) do
+        {:ok, selected} ->
+          {:ok, selected}
+
+        :error when is_atom(segment) ->
+          Map.fetch(value, Atom.to_string(segment))
+
+        :error ->
+          :error
+      end
+
+    case selected do
+      {:ok, result} -> result
+      :error -> missing_segment!(value, segment, connection)
+    end
+  end
+
+  defp fetch_segment(value, segment, _position, connection)
+       when is_list(value) and is_atom(segment) do
+    case Keyword.fetch(value, segment) do
+      {:ok, selected} -> selected
+      :error -> missing_segment!(value, segment, connection)
+    end
+  end
+
+  defp fetch_segment(value, _segment, position, connection)
+       when is_list(value) and is_integer(position) do
+    case Enum.fetch(value, position) do
+      {:ok, selected} -> selected
+      :error -> missing_segment!(value, position, connection)
+    end
+  end
+
+  defp fetch_segment(value, _segment, position, _connection)
+       when is_tuple(value) and is_integer(position) and position >= 0 and
+              position < tuple_size(value),
+       do: elem(value, position)
+
+  defp fetch_segment(value, segment, _position, connection),
+    do: missing_segment!(value, segment, connection)
+
+  defp missing_segment!(value, segment, connection) do
+    binding_error!(
+      "cannot read segment #{inspect(segment)} from #{inspect(value)} for connection #{inspect(connection.id)}",
+      connection,
+      [segment]
+    )
+  end
+
+  defp put_target_value(acc, port, [], value, connection) do
+    if Map.has_key?(acc, port) do
+      binding_error!("target port #{inspect(port)} is assigned more than once", connection, [])
+    end
+
+    Map.put(acc, port, value)
+  end
+
+  defp put_target_value(acc, port, path, value, connection) do
+    current = Map.get(acc, port, container_for(path))
+    Map.put(acc, port, put_path(current, path, value, connection))
+  end
+
+  defp put_path(_current, [], value, _connection), do: value
+
+  defp put_path(current, [segment | rest], value, connection)
+       when is_atom(segment) or is_binary(segment) do
+    map = if is_nil(current), do: %{}, else: current
+
+    unless is_map(map) do
+      binding_error!(
+        "target path requires a map at #{inspect(segment)}, got: #{inspect(map)}",
+        connection,
+        [segment | rest]
+      )
+    end
+
+    child = Map.get(map, segment, container_for(rest))
+    Map.put(map, segment, put_path(child, rest, value, connection))
+  end
+
+  defp put_path(current, [segment | rest], value, connection)
+       when is_integer(segment) and segment >= 0 do
+    list = if is_nil(current), do: [], else: current
+
+    unless is_list(list) do
+      binding_error!(
+        "target path requires a list at index #{segment}, got: #{inspect(list)}",
+        connection,
+        [segment | rest]
+      )
+    end
+
+    list = pad_list(list, segment + 1)
+
+    child =
+      case Enum.fetch(list, segment) do
+        {:ok, nil} -> container_for(rest)
+        {:ok, existing} -> existing
+      end
+
+    List.replace_at(list, segment, put_path(child, rest, value, connection))
+  end
+
+  defp container_for([]), do: nil
+  defp container_for([segment | _]) when is_integer(segment), do: []
+  defp container_for(_path), do: %{}
+
+  defp pad_list(list, size) do
+    list ++ List.duplicate(nil, max(size - length(list), 0))
+  end
+
+  defp binding_error!(message, connection, path) do
+    raise Runic.InputBindingError, message: message, connection: connection, path: path
+  end
+end

--- a/lib/workflow/invocation.ex
+++ b/lib/workflow/invocation.ex
@@ -2,6 +2,7 @@ defmodule Runic.Workflow.Invocation do
   @moduledoc false
 
   alias Runic.Workflow.{CallContract, CausalContext}
+  alias Runic.Workflow.Invocation.Plan
 
   @type context :: %{
           runtime: map(),
@@ -29,8 +30,18 @@ defmodule Runic.Workflow.Invocation do
   defstruct [:value, :arguments, :context, :bindings, :contract, version: 1]
 
   @doc false
-  @spec prepare(CallContract.t(), term(), CausalContext.t()) :: t()
-  def prepare(%CallContract{} = contract, value, %CausalContext{} = causal_context) do
+  @spec plan(CallContract.t()) :: Plan.t()
+  def plan(%CallContract{} = contract) do
+    %Plan{contract: CallContract.validate!(contract)}
+  end
+
+  @doc false
+  @spec materialize(Plan.t(), term(), CausalContext.t()) :: t()
+  def materialize(
+        %Plan{version: 1, contract: contract},
+        value,
+        %CausalContext{} = causal_context
+      ) do
     contract = CallContract.validate!(contract)
     arguments = prepare_arguments(contract, value)
     effective_context = merge_context(causal_context.meta_context, causal_context.run_context)
@@ -51,6 +62,10 @@ defmodule Runic.Workflow.Invocation do
       },
       contract: contract
     }
+  end
+
+  def materialize(%Plan{version: version}, _value, %CausalContext{}) do
+    raise ArgumentError, "unsupported invocation plan version: #{inspect(version)}"
   end
 
   @doc false

--- a/lib/workflow/invocation.ex
+++ b/lib/workflow/invocation.ex
@@ -1,0 +1,117 @@
+defmodule Runic.Workflow.Invocation do
+  @moduledoc false
+
+  alias Runic.Workflow.{CallContract, CausalContext}
+
+  @type context :: %{
+          runtime: map(),
+          meta: map(),
+          effective: map()
+        }
+
+  @type bindings :: %{
+          inputs: map(),
+          sources: list(map()),
+          meta: map(),
+          refs: list(map())
+        }
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          value: term(),
+          arguments: list(),
+          context: context(),
+          bindings: bindings(),
+          contract: CallContract.t()
+        }
+
+  @enforce_keys [:value, :arguments, :context, :bindings, :contract]
+  defstruct [:value, :arguments, :context, :bindings, :contract, version: 1]
+
+  @doc false
+  @spec prepare(CallContract.t(), term(), CausalContext.t()) :: t()
+  def prepare(%CallContract{} = contract, value, %CausalContext{} = causal_context) do
+    contract = CallContract.validate!(contract)
+    arguments = prepare_arguments(contract, value)
+    effective_context = merge_context(causal_context.meta_context, causal_context.run_context)
+
+    %__MODULE__{
+      value: value,
+      arguments: arguments,
+      context: %{
+        runtime: causal_context.run_context,
+        meta: causal_context.meta_context,
+        effective: effective_context
+      },
+      bindings: %{
+        inputs: bind_inputs(contract.input_order, arguments),
+        sources: source_bindings(causal_context.input_fact),
+        meta: causal_context.meta_context,
+        refs: contract.binding_refs
+      },
+      contract: contract
+    }
+  end
+
+  @doc false
+  @spec call(t(), function()) :: term()
+  def call(%__MODULE__{version: 1, contract: contract} = invocation, work)
+      when is_function(work) do
+    contract = CallContract.validate!(contract)
+
+    arguments =
+      case contract.style do
+        :zero_arity -> []
+        :single_input -> [invocation.value]
+        :positional -> invocation.arguments
+        :input_and_context -> [invocation.value, invocation.context.effective]
+      end
+
+    apply(work, arguments)
+  end
+
+  def call(%__MODULE__{version: version}, work) when is_function(work) do
+    raise ArgumentError, "unsupported invocation version: #{inspect(version)}"
+  end
+
+  defp prepare_arguments(%CallContract{style: :zero_arity}, _value), do: []
+
+  defp prepare_arguments(%CallContract{style: style}, value)
+       when style in [:single_input, :input_and_context],
+       do: [value]
+
+  defp prepare_arguments(%CallContract{style: :positional, authored_arity: arity}, value)
+       when is_list(value) do
+    if length(value) == arity do
+      value
+    else
+      raise ArgumentError,
+            "positional invocation expected #{arity} values, got #{length(value)}"
+    end
+  end
+
+  defp prepare_arguments(%CallContract{style: :positional, authored_arity: arity}, value) do
+    raise ArgumentError,
+          "positional invocation expected a list of #{arity} values, got: #{inspect(value)}"
+  end
+
+  defp bind_inputs(input_order, arguments) do
+    if length(input_order) == length(arguments) do
+      Map.new(Enum.zip(input_order, arguments))
+    else
+      raise ArgumentError,
+            "call contract declares #{length(input_order)} input bindings for #{length(arguments)} arguments"
+    end
+  end
+
+  defp source_bindings(%{meta: %{runic: %{input_bindings: bindings}}})
+       when is_list(bindings),
+       do: bindings
+
+  defp source_bindings(_input_fact), do: []
+
+  defp merge_context(meta, run) when map_size(meta) == 0 and map_size(run) == 0, do: %{}
+  defp merge_context(meta, run) when map_size(run) == 0, do: meta
+  defp merge_context(meta, run) when map_size(meta) == 0, do: run
+  defp merge_context(meta, run), do: Map.merge(run, meta)
+end

--- a/lib/workflow/invocation/plan.ex
+++ b/lib/workflow/invocation/plan.ex
@@ -1,0 +1,13 @@
+defmodule Runic.Workflow.Invocation.Plan do
+  @moduledoc false
+
+  alias Runic.Workflow.CallContract
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          contract: CallContract.t()
+        }
+
+  @enforce_keys [:contract]
+  defstruct [:contract, version: 1]
+end

--- a/lib/workflow/invokable.ex
+++ b/lib/workflow/invokable.ex
@@ -364,7 +364,8 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
   alias Runic.Workflow.{
     Fact,
     Step,
-    Components,
+    CallContract,
+    Invocation,
     Runnable,
     CausalContext,
     HookRunner
@@ -379,7 +380,13 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
         %Workflow{} = workflow,
         %Fact{} = fact
       ) do
-    result = Components.run(step.work, fact.value, Components.arity_of(step.work))
+    context = build_context(step, workflow, fact)
+
+    result =
+      step
+      |> CallContract.for_step()
+      |> Invocation.prepare(fact.value, context)
+      |> Invocation.call(step.work)
 
     result_fact = Fact.new(value: result, ancestry: {step.hash, fact.hash})
 
@@ -395,35 +402,31 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
   end
 
   def prepare(%Step{} = step, %Workflow{} = workflow, %Fact{} = fact) do
-    fan_out_context = build_fan_out_context(workflow, step, fact)
+    context = build_context(step, workflow, fact)
 
-    meta_context =
-      if Step.has_meta_refs?(step) do
-        Workflow.prepare_meta_context(workflow, step)
-      else
-        %{}
-      end
+    invocation =
+      step
+      |> CallContract.for_step()
+      |> Invocation.prepare(fact.value, context)
 
-    run_context = Workflow.get_run_context(workflow, step.name)
+    runnable =
+      step
+      |> Runnable.new(fact, context)
+      |> Runnable.with_invocation(invocation)
 
-    context =
-      CausalContext.new(
-        node_hash: step.hash,
-        input_fact: fact,
-        ancestry_depth: Workflow.ancestry_depth(workflow, fact),
-        hooks: Workflow.get_hooks(workflow, step.hash),
-        fan_out_context: fan_out_context,
-        meta_context: meta_context,
-        run_context: run_context
-      )
-
-    {:ok, Runnable.new(step, fact, context)}
+    {:ok, runnable}
   end
 
   def execute(%Step{} = step, %Runnable{input_fact: fact, context: ctx} = runnable) do
+    invocation =
+      runnable.invocation ||
+        step
+        |> CallContract.for_step()
+        |> Invocation.prepare(fact.value, ctx)
+
     with {:ok, before_apply_fns} <- HookRunner.run_before(ctx, step, fact) do
       try do
-        result = run_step_work(step, fact.value, ctx)
+        result = Invocation.call(invocation, step.work)
 
         result_fact = Fact.new(value: result, ancestry: {step.hash, fact.hash})
 
@@ -446,36 +449,28 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
     end
   end
 
-  defp run_step_work(step, input, ctx) do
-    effective_context = merge_effective_context(ctx.meta_context, ctx.run_context)
-    arity = Components.arity_of(step.work)
+  defp build_context(step, workflow, fact) do
+    fan_out_context = build_fan_out_context(workflow, step, fact)
 
-    cond do
-      step.invocation == :positional_inputs ->
-        Components.run(step.work, input, arity)
+    meta_context =
+      if Step.has_meta_refs?(step) do
+        Workflow.prepare_meta_context(workflow, step)
+      else
+        %{}
+      end
 
-      step.invocation == :input_and_context and arity == 2 ->
-        step.work.(input, effective_context)
+    run_context = Workflow.get_run_context(workflow, step.name)
 
-      step.invocation == :input_and_context ->
-        raise ArgumentError,
-              "step #{inspect(step.name)} uses :input_and_context but its work function has arity #{arity}"
-
-      effective_context != %{} and arity >= 2 ->
-        step.work.(input, effective_context)
-
-      Step.has_meta_refs?(step) and ctx.meta_context != %{} ->
-        Step.run_with_meta_context(step, input, ctx.meta_context)
-
-      true ->
-        Components.run(step.work, input, arity)
-    end
+    CausalContext.new(
+      node_hash: step.hash,
+      input_fact: fact,
+      ancestry_depth: Workflow.ancestry_depth(workflow, fact),
+      hooks: Workflow.get_hooks(workflow, step.hash),
+      fan_out_context: fan_out_context,
+      meta_context: meta_context,
+      run_context: run_context
+    )
   end
-
-  defp merge_effective_context(meta, run) when map_size(meta) == 0 and map_size(run) == 0, do: %{}
-  defp merge_effective_context(meta, run) when map_size(run) == 0, do: meta
-  defp merge_effective_context(meta, run) when map_size(meta) == 0, do: run
-  defp merge_effective_context(meta, run), do: Map.merge(run, meta)
 
   defp build_events(step, input_fact, result_fact, ctx) do
     events = [
@@ -669,7 +664,14 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.InputBinding do
 
   def invoke(%InputBinding{} = binding, %Workflow{} = workflow, %Fact{} = fact) do
     result = InputBinding.bind(binding, fact.value)
-    result_fact = Fact.new(value: result, ancestry: {binding.hash, fact.hash})
+
+    result_fact =
+      Fact.new(
+        value: result,
+        ancestry: {binding.hash, fact.hash},
+        meta: InputBinding.fact_meta(binding)
+      )
+
     causal_depth = Workflow.ancestry_depth(workflow, fact) + 1
 
     workflow
@@ -693,7 +695,13 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.InputBinding do
   def execute(%InputBinding{} = binding, %Runnable{input_fact: fact, context: ctx} = runnable) do
     try do
       result = InputBinding.bind(binding, fact.value)
-      result_fact = Fact.new(value: result, ancestry: {binding.hash, fact.hash})
+
+      result_fact =
+        Fact.new(
+          value: result,
+          ancestry: {binding.hash, fact.hash},
+          meta: InputBinding.fact_meta(binding)
+        )
 
       events = [
         %FactProduced{
@@ -701,7 +709,8 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.InputBinding do
           value: result_fact.value,
           ancestry: result_fact.ancestry,
           producer_label: :produced,
-          weight: ctx.ancestry_depth + 1
+          weight: ctx.ancestry_depth + 1,
+          meta: result_fact.meta
         },
         %ActivationConsumed{
           fact_hash: fact.hash,

--- a/lib/workflow/invokable.ex
+++ b/lib/workflow/invokable.ex
@@ -385,7 +385,8 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
     result =
       step
       |> CallContract.for_step()
-      |> Invocation.prepare(fact.value, context)
+      |> Invocation.plan()
+      |> Invocation.materialize(fact.value, context)
       |> Invocation.call(step.work)
 
     result_fact = Fact.new(value: result, ancestry: {step.hash, fact.hash})
@@ -407,7 +408,7 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
     invocation =
       step
       |> CallContract.for_step()
-      |> Invocation.prepare(fact.value, context)
+      |> Invocation.plan()
 
     runnable =
       step
@@ -422,10 +423,11 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
       runnable.invocation ||
         step
         |> CallContract.for_step()
-        |> Invocation.prepare(fact.value, ctx)
+        |> Invocation.plan()
 
     with {:ok, before_apply_fns} <- HookRunner.run_before(ctx, step, fact) do
       try do
+        invocation = Invocation.materialize(invocation, fact.value, ctx)
         result = Invocation.call(invocation, step.work)
 
         result_fact = Fact.new(value: result, ancestry: {step.hash, fact.hash})

--- a/lib/workflow/invokable.ex
+++ b/lib/workflow/invokable.ex
@@ -451,6 +451,16 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
     arity = Components.arity_of(step.work)
 
     cond do
+      step.invocation == :positional_inputs ->
+        Components.run(step.work, input, arity)
+
+      step.invocation == :input_and_context and arity == 2 ->
+        step.work.(input, effective_context)
+
+      step.invocation == :input_and_context ->
+        raise ArgumentError,
+              "step #{inspect(step.name)} uses :input_and_context but its work function has arity #{arity}"
+
       effective_context != %{} and arity >= 2 ->
         step.work.(input, effective_context)
 
@@ -647,6 +657,64 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
   # def runnable_connection(_step), do: :runnable
   # def resolved_connection(_step), do: :ran
   # def causal_connection(_step), do: :produced
+end
+
+defimpl Runic.Workflow.Invokable, for: Runic.Workflow.InputBinding do
+  alias Runic.Workflow
+
+  alias Runic.Workflow.{CausalContext, Fact, InputBinding, Runnable}
+  alias Runic.Workflow.Events.{ActivationConsumed, FactProduced}
+
+  def match_or_execute(_binding), do: :execute
+
+  def invoke(%InputBinding{} = binding, %Workflow{} = workflow, %Fact{} = fact) do
+    result = InputBinding.bind(binding, fact.value)
+    result_fact = Fact.new(value: result, ancestry: {binding.hash, fact.hash})
+    causal_depth = Workflow.ancestry_depth(workflow, fact) + 1
+
+    workflow
+    |> Workflow.log_fact(result_fact)
+    |> Workflow.draw_connection(binding, result_fact, :produced, weight: causal_depth)
+    |> Workflow.mark_runnable_as_ran(binding, fact)
+    |> Workflow.prepare_next_runnables(binding, result_fact)
+  end
+
+  def prepare(%InputBinding{} = binding, %Workflow{} = workflow, %Fact{} = fact) do
+    context =
+      CausalContext.new(
+        node_hash: binding.hash,
+        input_fact: fact,
+        ancestry_depth: Workflow.ancestry_depth(workflow, fact)
+      )
+
+    {:ok, Runnable.new(binding, fact, context)}
+  end
+
+  def execute(%InputBinding{} = binding, %Runnable{input_fact: fact, context: ctx} = runnable) do
+    try do
+      result = InputBinding.bind(binding, fact.value)
+      result_fact = Fact.new(value: result, ancestry: {binding.hash, fact.hash})
+
+      events = [
+        %FactProduced{
+          hash: result_fact.hash,
+          value: result_fact.value,
+          ancestry: result_fact.ancestry,
+          producer_label: :produced,
+          weight: ctx.ancestry_depth + 1
+        },
+        %ActivationConsumed{
+          fact_hash: fact.hash,
+          node_hash: binding.hash,
+          from_label: :runnable
+        }
+      ]
+
+      Runnable.complete(runnable, result_fact, events)
+    rescue
+      error -> Runnable.fail(runnable, error)
+    end
+  end
 end
 
 defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Conjunction do

--- a/lib/workflow/runnable.ex
+++ b/lib/workflow/runnable.ex
@@ -15,11 +15,12 @@ defmodule Runic.Workflow.Runnable do
   - The node to invoke
   - The input fact triggering invocation
   - Minimal causal context (no full workflow reference)
-  - A prepared, data-only invocation envelope when the node has a call contract
+  - A compact, data-only invocation plan when the node has a call contract
   - After execution: result, status, and events for reducing into workflow
   """
 
-  alias Runic.Workflow.{Fact, CausalContext, Invocation}
+  alias Runic.Workflow.{Fact, CausalContext}
+  alias Runic.Workflow.Invocation.Plan
 
   @type status :: :pending | :completed | :failed | :skipped
 
@@ -28,7 +29,7 @@ defmodule Runic.Workflow.Runnable do
           node: struct(),
           input_fact: Fact.t(),
           context: CausalContext.t() | nil,
-          invocation: map() | nil,
+          invocation: Plan.t() | nil,
           status: status(),
           result: term() | nil,
           events: [struct()] | nil,
@@ -80,8 +81,8 @@ defmodule Runic.Workflow.Runnable do
   end
 
   @doc false
-  @spec with_invocation(t(), Invocation.t()) :: t()
-  def with_invocation(%__MODULE__{} = runnable, %Invocation{} = invocation) do
+  @spec with_invocation(t(), Plan.t()) :: t()
+  def with_invocation(%__MODULE__{} = runnable, %Plan{} = invocation) do
     %{runnable | invocation: invocation}
   end
 

--- a/lib/workflow/runnable.ex
+++ b/lib/workflow/runnable.ex
@@ -29,7 +29,7 @@ defmodule Runic.Workflow.Runnable do
           node: struct(),
           input_fact: Fact.t(),
           context: CausalContext.t() | nil,
-          invocation: Plan.t() | nil,
+          invocation: map() | nil,
           status: status(),
           result: term() | nil,
           events: [struct()] | nil,

--- a/lib/workflow/runnable.ex
+++ b/lib/workflow/runnable.ex
@@ -15,10 +15,11 @@ defmodule Runic.Workflow.Runnable do
   - The node to invoke
   - The input fact triggering invocation
   - Minimal causal context (no full workflow reference)
+  - A prepared, data-only invocation envelope when the node has a call contract
   - After execution: result, status, and events for reducing into workflow
   """
 
-  alias Runic.Workflow.{Fact, CausalContext}
+  alias Runic.Workflow.{Fact, CausalContext, Invocation}
 
   @type status :: :pending | :completed | :failed | :skipped
 
@@ -27,6 +28,7 @@ defmodule Runic.Workflow.Runnable do
           node: struct(),
           input_fact: Fact.t(),
           context: CausalContext.t() | nil,
+          invocation: map() | nil,
           status: status(),
           result: term() | nil,
           events: [struct()] | nil,
@@ -39,6 +41,7 @@ defmodule Runic.Workflow.Runnable do
     :node,
     :input_fact,
     :context,
+    :invocation,
     :status,
     :result,
     :events,
@@ -74,6 +77,12 @@ defmodule Runic.Workflow.Runnable do
       context: context,
       status: :pending
     }
+  end
+
+  @doc false
+  @spec with_invocation(t(), Invocation.t()) :: t()
+  def with_invocation(%__MODULE__{} = runnable, %Invocation{} = invocation) do
+    %{runnable | invocation: invocation}
   end
 
   @doc """

--- a/lib/workflow/serializer.ex
+++ b/lib/workflow/serializer.ex
@@ -59,6 +59,8 @@ defmodule Runic.Workflow.Serializer do
 
   def node_label(%Runic.Workflow.Join{hash: hash}), do: "Join(#{hash})"
 
+  def node_label(%Runic.Workflow.InputBinding{hash: hash}), do: "InputBinding(#{hash})"
+
   def node_label(%Runic.Workflow.Accumulator{name: name}) when not is_nil(name),
     do: "Acc: #{escape_label(name)}"
 
@@ -108,6 +110,7 @@ defmodule Runic.Workflow.Serializer do
   def node_shape(%Runic.Workflow.FanOut{}), do: {:parallelogram, "[/", "/]"}
   def node_shape(%Runic.Workflow.FanIn{}), do: {:parallelogram, "[\\", "\\]"}
   def node_shape(%Runic.Workflow.Join{}), do: {:hexagon, "{{", "}}"}
+  def node_shape(%Runic.Workflow.InputBinding{}), do: {:rect, "[", "]"}
   def node_shape(%Runic.Workflow.Accumulator{}), do: {:cylinder, "[(", ")]"}
   def node_shape(%Runic.Workflow.Rule{}), do: {:subroutine, "[[", "]]"}
   def node_shape(%Runic.Workflow.Map{}), do: {:stadium, "([", "])"}
@@ -126,6 +129,7 @@ defmodule Runic.Workflow.Serializer do
   def node_class(%Runic.Workflow.FanOut{}), do: "fanout"
   def node_class(%Runic.Workflow.FanIn{}), do: "fanin"
   def node_class(%Runic.Workflow.Join{}), do: "join"
+  def node_class(%Runic.Workflow.InputBinding{}), do: "inputbinding"
   def node_class(%Runic.Workflow.Accumulator{}), do: "accumulator"
   def node_class(%Runic.Workflow.Rule{}), do: "rule"
   def node_class(%Runic.Workflow.Map{}), do: "map"

--- a/lib/workflow/serializers/cytoscape.ex
+++ b/lib/workflow/serializers/cytoscape.ex
@@ -201,6 +201,7 @@ defmodule Runic.Workflow.Serializers.Cytoscape do
   defp node_cytoscape_style(%Workflow.FanOut{}), do: {"rhomboid", "#2c5282"}
   defp node_cytoscape_style(%Workflow.FanIn{}), do: {"rhomboid", "#285e61"}
   defp node_cytoscape_style(%Workflow.Join{}), do: {"hexagon", "#744210"}
+  defp node_cytoscape_style(%Workflow.InputBinding{}), do: {"rectangle", "#4a3f35"}
   defp node_cytoscape_style(%Workflow.Accumulator{}), do: {"barrel", "#22543d"}
   defp node_cytoscape_style(%Workflow.Rule{}), do: {"octagon", "#742a2a"}
   defp node_cytoscape_style(%Workflow.Map{}), do: {"round-rectangle", "#1a365d"}

--- a/lib/workflow/serializers/dot.ex
+++ b/lib/workflow/serializers/dot.ex
@@ -181,6 +181,7 @@ defmodule Runic.Workflow.Serializers.DOT do
   defp node_style(%Workflow.FanOut{}), do: {"parallelogram", "#2c5282", "white"}
   defp node_style(%Workflow.FanIn{}), do: {"parallelogram", "#285e61", "white"}
   defp node_style(%Workflow.Join{}), do: {"hexagon", "#744210", "white"}
+  defp node_style(%Workflow.InputBinding{}), do: {"box", "#4a3f35", "white"}
   defp node_style(%Workflow.Accumulator{}), do: {"cylinder", "#22543d", "white"}
   defp node_style(%Workflow.Rule{}), do: {"doubleoctagon", "#742a2a", "white"}
   defp node_style(%Workflow.Map{}), do: {"component", "#1a365d", "white"}

--- a/lib/workflow/serializers/mermaid.ex
+++ b/lib/workflow/serializers/mermaid.ex
@@ -351,6 +351,7 @@ defmodule Runic.Workflow.Serializers.Mermaid do
         "    classDef fanout fill:#2c5282,stroke:#63b3ed,color:#fff",
         "    classDef fanin fill:#285e61,stroke:#4fd1c5,color:#fff",
         "    classDef join fill:#744210,stroke:#f6ad55,color:#fff",
+        "    classDef inputbinding fill:#4a3f35,stroke:#fbd38d,color:#fff,stroke-dasharray:3",
         "    classDef accumulator fill:#22543d,stroke:#68d391,color:#fff",
         "    classDef rule fill:#742a2a,stroke:#fc8181,color:#fff",
         "    classDef map fill:#1a365d,stroke:#90cdf4,color:#fff",

--- a/lib/workflow/step.ex
+++ b/lib/workflow/step.ex
@@ -98,7 +98,8 @@ defmodule Runic.Workflow.Step do
     invocation =
       step
       |> CallContract.for_step()
-      |> Invocation.prepare(input, CausalContext.new())
+      |> Invocation.plan()
+      |> Invocation.materialize(input, CausalContext.new())
 
     Invocation.call(invocation, step.work)
   end
@@ -122,7 +123,8 @@ defmodule Runic.Workflow.Step do
     invocation =
       step
       |> CallContract.for_step()
-      |> Invocation.prepare(input, CausalContext.new(meta_context: meta_context))
+      |> Invocation.plan()
+      |> Invocation.materialize(input, CausalContext.new(meta_context: meta_context))
 
     Invocation.call(invocation, step.work)
   end

--- a/lib/workflow/step.ex
+++ b/lib/workflow/step.ex
@@ -24,6 +24,23 @@ defmodule Runic.Workflow.Step do
   When `context/1` is detected, the step's work function is rewritten to arity-2
   `(input, meta_ctx)` and `meta_refs` are populated with `kind: :context` entries.
   Values are resolved from the workflow's `run_context` during the prepare phase.
+
+  ## Explicit Invocation
+
+  An arity-2 function is otherwise ambiguous when a step may receive either two
+  joined inputs or `(input, runtime_context)`. Named multi-port connections
+  therefore require an explicit invocation mode:
+
+      Runic.step(fn left, right -> left + right end,
+        inputs: [left: [type: :integer], right: [type: :integer]],
+        invocation: :positional_inputs
+      )
+
+      Runic.step(fn input, context -> call_service(input, context) end,
+        invocation: :input_and_context
+      )
+
+  Existing steps default to `:legacy`, preserving the prior inference behavior.
   """
 
   alias Runic.Workflow.Step
@@ -46,6 +63,7 @@ defmodule Runic.Workflow.Step do
           closure: Closure.t() | nil,
           inputs: term(),
           outputs: term(),
+          invocation: :legacy | :positional_inputs | :input_and_context,
           meta_refs: list(meta_ref())
         }
 
@@ -57,13 +75,16 @@ defmodule Runic.Workflow.Step do
     :closure,
     :inputs,
     :outputs,
+    invocation: :legacy,
     meta_refs: []
   ]
 
   def new(params) do
     params_map = if Keyword.keyword?(params), do: Map.new(params), else: params
 
-    struct!(__MODULE__, params_map)
+    __MODULE__
+    |> struct!(params_map)
+    |> validate_invocation!()
     |> maybe_hash_work()
     |> maybe_set_name()
   end
@@ -113,5 +134,14 @@ defmodule Runic.Workflow.Step do
       1 -> work.(input)
       0 -> work.()
     end
+  end
+
+  defp validate_invocation!(%__MODULE__{invocation: invocation} = step)
+       when invocation in [:legacy, :positional_inputs, :input_and_context],
+       do: step
+
+  defp validate_invocation!(%__MODULE__{invocation: invocation}) do
+    raise ArgumentError,
+          ":invocation must be :legacy, :positional_inputs, or :input_and_context, got: #{inspect(invocation)}"
   end
 end

--- a/lib/workflow/step.ex
+++ b/lib/workflow/step.ex
@@ -25,27 +25,14 @@ defmodule Runic.Workflow.Step do
   `(input, meta_ctx)` and `meta_refs` are populated with `kind: :context` entries.
   Values are resolved from the workflow's `run_context` during the prepare phase.
 
-  ## Explicit Invocation
-
-  An arity-2 function is otherwise ambiguous when a step may receive either two
-  joined inputs or `(input, runtime_context)`. Named multi-port connections
-  therefore require an explicit invocation mode:
-
-      Runic.step(fn left, right -> left + right end,
-        inputs: [left: [type: :integer], right: [type: :integer]],
-        invocation: :positional_inputs
-      )
-
-      Runic.step(fn input, context -> call_service(input, context) end,
-        invocation: :input_and_context
-      )
-
-  Existing steps default to `:legacy`, preserving the prior inference behavior.
+  Runic compiles each authored function into an internal, versioned call
+  contract. Ordinary multi-arity functions receive positional data inputs;
+  functions rewritten from documented meta expressions receive the complete
+  input plus prepared context. The internal calling convention is not part of
+  the user-facing step API.
   """
 
-  alias Runic.Workflow.Step
-  alias Runic.Workflow.Fact
-  alias Runic.Workflow.Components
+  alias Runic.Workflow.{CallContract, CausalContext, Components, Fact, Invocation, Step}
   alias Runic.Closure
 
   @type meta_ref :: %{
@@ -63,7 +50,7 @@ defmodule Runic.Workflow.Step do
           closure: Closure.t() | nil,
           inputs: term(),
           outputs: term(),
-          invocation: :legacy | :positional_inputs | :input_and_context,
+          call_contract: map() | nil,
           meta_refs: list(meta_ref())
         }
 
@@ -75,7 +62,7 @@ defmodule Runic.Workflow.Step do
     :closure,
     :inputs,
     :outputs,
-    invocation: :legacy,
+    :call_contract,
     meta_refs: []
   ]
 
@@ -84,7 +71,7 @@ defmodule Runic.Workflow.Step do
 
     __MODULE__
     |> struct!(params_map)
-    |> validate_invocation!()
+    |> compile_call_contract()
     |> maybe_hash_work()
     |> maybe_set_name()
   end
@@ -108,7 +95,12 @@ defmodule Runic.Workflow.Step do
   Executes the work function of the Lambda step returning the raw unwrapped value.
   """
   def run(%__MODULE__{} = step, input) when not is_struct(input, Fact) do
-    Components.run(step.work, input)
+    invocation =
+      step
+      |> CallContract.for_step()
+      |> Invocation.prepare(input, CausalContext.new())
+
+    Invocation.call(invocation, step.work)
   end
 
   @doc """
@@ -125,23 +117,24 @@ defmodule Runic.Workflow.Step do
   receiving `(input, meta_context)`.
   """
   @spec run_with_meta_context(t(), term(), map()) :: term()
-  def run_with_meta_context(%__MODULE__{work: work}, input, meta_context)
+  def run_with_meta_context(%__MODULE__{} = step, input, meta_context)
       when is_map(meta_context) do
-    arity = Function.info(work, :arity) |> elem(1)
+    invocation =
+      step
+      |> CallContract.for_step()
+      |> Invocation.prepare(input, CausalContext.new(meta_context: meta_context))
 
-    case arity do
-      2 -> work.(input, meta_context)
-      1 -> work.(input)
-      0 -> work.()
-    end
+    Invocation.call(invocation, step.work)
   end
 
-  defp validate_invocation!(%__MODULE__{invocation: invocation} = step)
-       when invocation in [:legacy, :positional_inputs, :input_and_context],
-       do: step
+  defp compile_call_contract(%__MODULE__{call_contract: nil} = step) do
+    %{step | call_contract: CallContract.compile(step)}
+  end
 
-  defp validate_invocation!(%__MODULE__{invocation: invocation}) do
-    raise ArgumentError,
-          ":invocation must be :legacy, :positional_inputs, or :input_and_context, got: #{inspect(invocation)}"
+  defp compile_call_contract(%__MODULE__{call_contract: %CallContract{} = contract} = step),
+    do: %{step | call_contract: CallContract.validate!(contract)}
+
+  defp compile_call_contract(%__MODULE__{call_contract: contract}) do
+    raise ArgumentError, "invalid step call contract: #{inspect(contract)}"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Runic.MixProject do
         Guides: ~r/guides\/.*/
       ],
       groups_for_modules: [
-        Core: [Runic, Runic.Workflow],
+        Core: [Runic, Runic.Workflow, Runic.Workflow.Connection],
         Components: [
           Runic.Workflow.Step,
           Runic.Workflow.Rule,

--- a/test/workflow/invocation_test.exs
+++ b/test/workflow/invocation_test.exs
@@ -1,0 +1,143 @@
+defmodule Runic.Workflow.InvocationTest do
+  use ExUnit.Case, async: true
+
+  require Runic
+
+  alias Runic.Workflow
+
+  alias Runic.Workflow.{
+    CallContract,
+    CausalContext,
+    Fact,
+    Invocation,
+    Invokable,
+    Runnable,
+    Step
+  }
+
+  describe "call contract compilation" do
+    test "compiles ordinary authored arities without a user invocation option" do
+      zero = Step.new(work: fn -> :ready end)
+      single = Step.new(work: fn input -> input end)
+
+      positional =
+        Step.new(
+          work: fn left, right -> left + right end,
+          inputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      assert %CallContract{style: :zero_arity, authored_arity: 0, input_order: []} =
+               zero.call_contract
+
+      assert %CallContract{style: :single_input, authored_arity: 1, input_order: [:in]} =
+               single.call_contract
+
+      assert %CallContract{
+               style: :positional,
+               authored_arity: 2,
+               input_order: [:left, :right]
+             } = positional.call_contract
+
+      refute Map.has_key?(positional, :invocation)
+    end
+
+    test "compiles context/1 as input and context from macro metadata" do
+      step = Runic.step(fn input -> input + context(:offset) end, name: :adjust)
+
+      assert %CallContract{
+               version: 1,
+               style: :input_and_context,
+               authored_arity: 1,
+               compiled_arity: 2,
+               input_order: [:in],
+               binding_refs: [%{kind: :context, target: :offset}]
+             } = step.call_contract
+    end
+
+    test "infers a deterministic current contract for a pre-contract step struct" do
+      step =
+        Step.new(
+          work: fn left, right -> left + right end,
+          inputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      old_step = Map.delete(step, :call_contract)
+
+      assert %CallContract{version: 1, style: :positional, input_order: [:left, :right]} =
+               CallContract.for_step(old_step)
+
+      invocation =
+        old_step
+        |> CallContract.for_step()
+        |> Invocation.prepare([2, 3], CausalContext.new(run_context: %{ignored: true}))
+
+      assert Invocation.call(invocation, old_step.work) == 5
+
+      workflow = Workflow.new() |> Workflow.add(old_step)
+      fact = Fact.new(value: [2, 3])
+
+      assert {:ok, %Runnable{invocation: %Invocation{}} = runnable} =
+               Invokable.prepare(old_step, workflow, fact)
+
+      assert %Runnable{status: :completed, result: %Fact{value: 5}} =
+               Invokable.execute(old_step, runnable)
+    end
+  end
+
+  describe "prepared invocation envelope" do
+    test "keeps the domain fact intact while exposing ordered and named bindings" do
+      step =
+        Step.new(
+          work: fn left, right -> left + right end,
+          name: :sum,
+          inputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(step)
+        |> Workflow.put_run_context(%{sum: %{request_id: "request-1"}})
+
+      fact = Fact.new(value: [4, 7])
+
+      assert {:ok, %Runnable{invocation: %Invocation{} = invocation}} =
+               Invokable.prepare(step, workflow, fact)
+
+      assert invocation.value == [4, 7]
+      assert invocation.arguments == [4, 7]
+      assert invocation.bindings.inputs == %{left: 4, right: 7}
+      assert invocation.context.runtime == %{request_id: "request-1"}
+      assert invocation.context.effective == %{request_id: "request-1"}
+      assert invocation.contract.style == :positional
+      assert invocation |> :erlang.term_to_binary() |> :erlang.binary_to_term() == invocation
+    end
+
+    test "context expressions receive merged context without changing the fact value" do
+      step = Runic.step(fn input -> {input, context(:model)} end, name: :call_model)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(step)
+        |> Workflow.put_run_context(%{
+          _global: %{request_id: "request-1"},
+          call_model: %{model: "model-1"}
+        })
+
+      fact = Fact.new(value: %{prompt: "hello"})
+      {:ok, runnable} = Invokable.prepare(step, workflow, fact)
+
+      assert runnable.invocation.value == %{prompt: "hello"}
+      assert runnable.invocation.arguments == [%{prompt: "hello"}]
+
+      assert runnable.invocation.context.effective == %{
+               model: "model-1",
+               request_id: "request-1"
+             }
+
+      assert %Runnable{status: :completed, result: %Fact{value: result}} =
+               Invokable.execute(step, runnable)
+
+      assert result == {%{prompt: "hello"}, "model-1"}
+    end
+  end
+end

--- a/test/workflow/invocation_test.exs
+++ b/test/workflow/invocation_test.exs
@@ -69,14 +69,18 @@ defmodule Runic.Workflow.InvocationTest do
       invocation =
         old_step
         |> CallContract.for_step()
-        |> Invocation.prepare([2, 3], CausalContext.new(run_context: %{ignored: true}))
+        |> Invocation.plan()
+        |> Invocation.materialize(
+          [2, 3],
+          CausalContext.new(run_context: %{ignored: true})
+        )
 
       assert Invocation.call(invocation, old_step.work) == 5
 
       workflow = Workflow.new() |> Workflow.add(old_step)
       fact = Fact.new(value: [2, 3])
 
-      assert {:ok, %Runnable{invocation: %Invocation{}} = runnable} =
+      assert {:ok, %Runnable{invocation: %Invocation.Plan{}} = runnable} =
                Invokable.prepare(old_step, workflow, fact)
 
       assert %Runnable{status: :completed, result: %Fact{value: 5}} =
@@ -84,8 +88,8 @@ defmodule Runic.Workflow.InvocationTest do
     end
   end
 
-  describe "prepared invocation envelope" do
-    test "keeps the domain fact intact while exposing ordered and named bindings" do
+  describe "compact plans and materialized invocation envelopes" do
+    test "keeps payloads out of the scheduled plan and materializes binding views on demand" do
       step =
         Step.new(
           work: fn left, right -> left + right end,
@@ -100,8 +104,17 @@ defmodule Runic.Workflow.InvocationTest do
 
       fact = Fact.new(value: [4, 7])
 
-      assert {:ok, %Runnable{invocation: %Invocation{} = invocation}} =
+      assert {:ok, %Runnable{invocation: %Invocation.Plan{} = plan} = runnable} =
                Invokable.prepare(step, workflow, fact)
+
+      assert plan.contract.style == :positional
+      refute Map.has_key?(plan, :value)
+      refute Map.has_key?(plan, :arguments)
+      refute Map.has_key?(plan, :context)
+      refute Map.has_key?(plan, :bindings)
+      assert plan |> :erlang.term_to_binary() |> :erlang.binary_to_term() == plan
+
+      invocation = Invocation.materialize(plan, fact.value, runnable.context)
 
       assert invocation.value == [4, 7]
       assert invocation.arguments == [4, 7]
@@ -126,10 +139,15 @@ defmodule Runic.Workflow.InvocationTest do
       fact = Fact.new(value: %{prompt: "hello"})
       {:ok, runnable} = Invokable.prepare(step, workflow, fact)
 
-      assert runnable.invocation.value == %{prompt: "hello"}
-      assert runnable.invocation.arguments == [%{prompt: "hello"}]
+      assert %Invocation.Plan{} = runnable.invocation
 
-      assert runnable.invocation.context.effective == %{
+      invocation =
+        Invocation.materialize(runnable.invocation, fact.value, runnable.context)
+
+      assert invocation.value == %{prompt: "hello"}
+      assert invocation.arguments == [%{prompt: "hello"}]
+
+      assert invocation.context.effective == %{
                model: "model-1",
                request_id: "request-1"
              }
@@ -138,6 +156,23 @@ defmodule Runic.Workflow.InvocationTest do
                Invokable.execute(step, runnable)
 
       assert result == {%{prompt: "hello"}, "model-1"}
+    end
+
+    test "does not retain the materialized envelope after execution" do
+      step =
+        Step.new(
+          work: fn left, right -> left + right end,
+          inputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      fact = Fact.new(value: [4, 7])
+      {:ok, runnable} = Invokable.prepare(step, Workflow.new() |> Workflow.add(step), fact)
+
+      assert %Runnable{
+               status: :completed,
+               invocation: %Invocation.Plan{},
+               result: %Fact{value: 11}
+             } = Invokable.execute(step, runnable)
     end
   end
 end

--- a/test/workflow/named_connection_test.exs
+++ b/test/workflow/named_connection_test.exs
@@ -11,6 +11,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
     Connection,
     Fact,
     InputBinding,
+    Invocation,
     Invokable,
     Join,
     Root
@@ -68,6 +69,9 @@ defmodule Runic.Workflow.NamedConnectionTest do
 
       assert {:ok, runnable} = Invokable.prepare(consumer, executed, bound_fact)
 
+      invocation =
+        Invocation.materialize(runnable.invocation, bound_fact.value, runnable.context)
+
       assert [
                %{
                  id: "score-binding",
@@ -75,7 +79,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
                  target_port: :score,
                  selector: [:score]
                }
-             ] = runnable.invocation.bindings.sources
+             ] = invocation.bindings.sources
     end
 
     test "assembles multiple sources in target port order, independent of declaration order" do

--- a/test/workflow/named_connection_test.exs
+++ b/test/workflow/named_connection_test.exs
@@ -1,0 +1,550 @@
+defmodule Runic.Workflow.NamedConnectionTest do
+  use ExUnit.Case, async: true
+
+  require Runic
+
+  alias Runic.Workflow
+
+  alias Runic.Workflow.{
+    ComponentAdded,
+    Connection,
+    Fact,
+    InputBinding,
+    Invokable,
+    Join,
+    Root
+  }
+
+  describe "named connection lowering" do
+    test "selects a safe path from one named output into one named input" do
+      producer =
+        Runic.step(fn input -> %{score: input + 2} end,
+          name: :producer,
+          outputs: [payload: [type: :any]]
+        )
+
+      consumer =
+        Runic.step(fn score -> score * 3 end,
+          name: :consumer,
+          inputs: [score: [type: :any]]
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [
+            [
+              id: "score-binding",
+              from: {:producer, :payload},
+              to: :score,
+              selector: [:score]
+            ]
+          ]
+        )
+
+      assert Workflow.raw_productions(Workflow.react_until_satisfied(workflow, 5), :consumer) ==
+               [21]
+
+      refute Enum.any?(Multigraph.vertices(workflow.graph), &match?(%Join{}, &1))
+
+      assert [
+               %{
+                 properties: %{
+                   kind: :port_binding,
+                   connections: [%Connection{id: "score-binding"}]
+                 }
+               }
+             ] =
+               Multigraph.edges(workflow.graph, by: :connects_to)
+
+      assert [%{v2: %InputBinding{}, properties: %{kind: :input_binding}}] =
+               Multigraph.out_edges(workflow.graph, consumer, by: :compiled_for)
+    end
+
+    test "assembles multiple sources in target port order, independent of declaration order" do
+      workflow = positional_sum_workflow()
+      workflow = Workflow.put_run_context(workflow, %{_global: %{request_id: "request-1"}})
+
+      assert Enum.count(Multigraph.vertices(workflow.graph), &match?(%Join{}, &1)) == 1
+
+      assert workflow
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:sum) == [16]
+    end
+
+    test "projects a named port from a multi-output domain value" do
+      producer =
+        Runic.step(fn input -> %{left: input + 1, right: input * 4} end,
+          name: :producer,
+          outputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      consumer =
+        Runic.step(fn value -> value + 3 end,
+          name: :consumer,
+          inputs: [value: [type: :integer]]
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [[from: {:producer, :right}, to: :value]]
+        )
+
+      assert workflow
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:consumer) == [23]
+    end
+
+    test "routes multiple ports from one source without introducing a Join" do
+      producer =
+        Runic.step(fn input -> %{left: input + 1, right: input * 2} end,
+          name: :producer,
+          outputs: [left: [type: :integer], right: [type: :integer]]
+        )
+
+      consumer =
+        Runic.step(fn left, right -> left + right end,
+          name: :consumer,
+          inputs: [left: [type: :integer], right: [type: :integer]],
+          invocation: :positional_inputs
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [
+            [from: {:producer, :left}, to: :left],
+            [from: {:producer, :right}, to: :right]
+          ]
+        )
+
+      refute Enum.any?(Multigraph.vertices(workflow.graph), &match?(%Join{}, &1))
+
+      assert [%{properties: %{connections: connections}}] =
+               Multigraph.edges(workflow.graph, by: :connects_to)
+
+      assert length(connections) == 2
+
+      assert workflow
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:consumer) == [16]
+    end
+
+    test "assembles distinct target paths without executable edge code" do
+      customer =
+        Runic.step(fn input -> input + 10 end,
+          name: :customer,
+          outputs: [id: [type: :integer]]
+        )
+
+      item =
+        Runic.step(fn input -> "item-#{input}" end,
+          name: :item,
+          outputs: [name: [type: :string]]
+        )
+
+      consumer =
+        Runic.step(fn payload -> payload end,
+          name: :consumer,
+          inputs: [payload: [type: :any]]
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(customer)
+        |> Workflow.add(item)
+        |> Workflow.add(consumer,
+          connections: [
+            [from: {:customer, :id}, to: :payload, target_path: [:customer, :id]],
+            [from: {:item, :name}, to: :payload, target_path: [:items, 0, :name]]
+          ]
+        )
+
+      assert workflow
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:consumer) == [
+               %{customer: %{id: 15}, items: [%{name: "item-5"}]}
+             ]
+    end
+  end
+
+  describe "durability and graph projections" do
+    test "add_with_events emits replayable normalized connection data" do
+      producer =
+        Runic.step(fn input -> input + 1 end,
+          name: :producer,
+          outputs: [value: [type: :integer]]
+        )
+
+      consumer =
+        Runic.step(fn input -> input * 2 end,
+          name: :consumer,
+          inputs: [value: [type: :integer]]
+        )
+
+      {workflow, producer_events} = Workflow.add_with_events(Workflow.new(), producer)
+
+      {original, consumer_events} =
+        Workflow.add_with_events(workflow, consumer,
+          connections: [[from: {:producer, :value}, to: :value]]
+        )
+
+      assert [
+               %ComponentAdded{
+                 to: nil,
+                 connections: [
+                   %Connection{source: :producer, target: :consumer, target_port: :value}
+                 ]
+               }
+             ] = consumer_events
+
+      rebuilt = Workflow.apply_events(Workflow.new(), producer_events ++ consumer_events)
+
+      for workflow <- [original, rebuilt] do
+        assert workflow
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:consumer) == [12]
+      end
+    end
+
+    test "round-trips deterministic connection data and equivalent lowering" do
+      original = positional_sum_workflow()
+
+      log =
+        original |> Workflow.build_log() |> :erlang.term_to_binary() |> :erlang.binary_to_term()
+
+      assert %ComponentAdded{connections: [%Connection{}, %Connection{}]} = List.last(log)
+
+      rebuilt = Workflow.from_log(log)
+
+      assert logical_inventory(original) == logical_inventory(rebuilt)
+      assert flow_inventory(original) == flow_inventory(rebuilt)
+
+      for workflow <- [original, rebuilt] do
+        assert workflow
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:sum) == [16]
+
+        assert Workflow.raw_productions_by_component(workflow).sum == []
+      end
+    end
+
+    test "component graph retains connection properties while flow graph retains lowering" do
+      workflow = positional_sum_workflow()
+      component_graph = Workflow.component_graph(workflow)
+      flow_graph = Workflow.flow_graph(workflow)
+
+      assert Enum.count(Multigraph.edges(component_graph, by: :connects_to)) == 2
+
+      assert Enum.all?(Multigraph.edges(component_graph), fn edge ->
+               match?(%{connections: [%Connection{}]}, edge.properties)
+             end)
+
+      assert Enum.empty?(Multigraph.edges(component_graph, by: :flow))
+      assert Enum.empty?(Multigraph.edges(flow_graph, by: :connects_to))
+      assert Enum.count(Multigraph.vertices(flow_graph), &match?(%InputBinding{}, &1)) == 1
+      assert Enum.count(Multigraph.vertices(flow_graph), &match?(%Join{}, &1)) == 1
+    end
+
+    test "serializers expose the binding as compiled topology without making it a component" do
+      workflow = positional_sum_workflow()
+
+      assert Workflow.to_mermaid(workflow) =~ "InputBinding"
+      assert Workflow.to_dot(workflow) =~ "InputBinding"
+
+      assert Enum.any?(Workflow.to_cytoscape(workflow), fn
+               %{data: %{kind: "inputbinding"}} -> true
+               _ -> false
+             end)
+
+      refute Map.has_key?(Workflow.components(workflow), :input_binding)
+
+      ran = Workflow.react_until_satisfied(workflow, 5)
+      assert Workflow.raw_productions(ran, :sum) == [16]
+      assert Workflow.raw_productions_by_component(ran).sum == [16]
+    end
+  end
+
+  describe "group validation and invocation semantics" do
+    test "validates each named source-target pair" do
+      producer =
+        Runic.step(fn input -> input end,
+          name: :producer,
+          outputs: [number: [type: :integer]]
+        )
+
+      consumer =
+        Runic.step(fn input -> input end,
+          name: :consumer,
+          inputs: [text: [type: :string]]
+        )
+
+      workflow = Workflow.new() |> Workflow.add(producer)
+
+      assert_raise Runic.IncompatiblePortError, fn ->
+        Workflow.add(workflow, consumer, connections: [[from: {:producer, :number}, to: :text]])
+      end
+    end
+
+    test "requires every required target port exactly once" do
+      producer = Runic.step(fn input -> input end, name: :producer)
+
+      consumer =
+        Runic.step(fn left, right -> {left, right} end,
+          name: :consumer,
+          inputs: [left: [type: :any], right: [type: :any]],
+          invocation: :positional_inputs
+        )
+
+      workflow = Workflow.new() |> Workflow.add(producer)
+
+      assert_raise ArgumentError, ~r/unassigned required input ports: \[:right\]/, fn ->
+        Workflow.add(workflow, consumer, connections: [[from: {:producer, :out}, to: :left]])
+      end
+    end
+
+    test "rejects overlapping target paths" do
+      first = Runic.step(fn input -> input end, name: :first)
+      second = Runic.step(fn input -> input end, name: :second)
+      consumer = Runic.step(fn input -> input end, name: :consumer)
+
+      workflow = Workflow.new() |> Workflow.add(first) |> Workflow.add(second)
+
+      assert_raise ArgumentError, ~r/overlapping assignments/, fn ->
+        Workflow.add(workflow, consumer,
+          connections: [
+            [from: {:first, :out}, to: :in, target_path: [:value]],
+            [from: {:second, :out}, to: :in, target_path: [:value, :nested]]
+          ]
+        )
+      end
+    end
+
+    test "requires explicit positional invocation for bound multi-input steps" do
+      left = Runic.step(fn input -> input end, name: :left)
+      right = Runic.step(fn input -> input end, name: :right)
+
+      ambiguous =
+        Runic.step(fn left, right -> left + right end,
+          name: :ambiguous,
+          inputs: [left: [type: :any], right: [type: :any]]
+        )
+
+      workflow = Workflow.new() |> Workflow.add(left) |> Workflow.add(right)
+
+      assert_raise ArgumentError, ~r/declare invocation: :positional_inputs/, fn ->
+        Workflow.add(workflow, ambiguous,
+          connections: [
+            [from: {:left, :out}, to: :left],
+            [from: {:right, :out}, to: :right]
+          ]
+        )
+      end
+    end
+
+    test "input_and_context is explicit and receives runtime context" do
+      producer = Runic.step(fn input -> input + 1 end, name: :producer)
+
+      consumer =
+        Runic.step(fn input, context -> input + Map.fetch!(context, :offset) end,
+          name: :consumer,
+          invocation: :input_and_context
+        )
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [[from: {:producer, :out}, to: :in]]
+        )
+        |> Workflow.put_run_context(%{consumer: %{offset: 10}})
+
+      rebuilt =
+        workflow
+        |> Workflow.build_log()
+        |> Workflow.from_log()
+        |> Workflow.put_run_context(%{consumer: %{offset: 10}})
+
+      for candidate <- [workflow, rebuilt] do
+        assert candidate
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:consumer) == [16]
+      end
+    end
+
+    test "selector failures retain precise connection evidence on the runnable" do
+      producer = Runic.step(fn input -> %{value: input} end, name: :producer)
+      consumer = Runic.step(fn input -> input end, name: :consumer)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [
+            [from: {:producer, :out}, to: :in, selector: [:missing]]
+          ]
+        )
+
+      binding = Enum.find(Multigraph.vertices(workflow.graph), &match?(%InputBinding{}, &1))
+      fact = Fact.new(value: %{value: 5})
+      {:ok, runnable} = Invokable.prepare(binding, workflow, fact)
+      executed = Invokable.execute(binding, runnable)
+
+      assert %{status: :failed, error: %Runic.InputBindingError{message: message}} = executed
+      assert message =~ ":missing"
+    end
+  end
+
+  describe "composite component boundaries" do
+    test "binds into a Rule condition entry" do
+      producer = Runic.step(fn input -> input + 1 end, name: :producer)
+      rule = Runic.rule(fn value when value > 5 -> {:large, value} end, name: :gate)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(rule,
+          connections: [[from: {:producer, :out}, to: :in]]
+        )
+
+      for candidate <- [workflow, workflow |> Workflow.build_log() |> Workflow.from_log()] do
+        assert candidate
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:gate) == [{:large, 6}]
+      end
+    end
+
+    test "binds into a Map fan-out entry" do
+      producer = Runic.step(fn _input -> [1, 2, 3] end, name: :producer)
+      map = Runic.map(fn value -> value * 2 end, name: :mapped)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(map,
+          connections: [[from: {:producer, :out}, to: :items]]
+        )
+
+      for candidate <- [workflow, workflow |> Workflow.build_log() |> Workflow.from_log()] do
+        assert candidate
+               |> Workflow.react_until_satisfied(:start)
+               |> Workflow.raw_productions(:mapped)
+               |> Enum.sort() == [2, 4, 6]
+      end
+    end
+
+    test "binds from a Rule reaction exit" do
+      rule = Runic.rule(fn value when value > 5 -> {:large, value} end, name: :gate)
+      consumer = Runic.step(fn {:large, value} -> value * 10 end, name: :consumer)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(rule)
+        |> Workflow.add(consumer,
+          connections: [[from: {:gate, :out}, to: :in]]
+        )
+
+      assert workflow
+             |> Workflow.react_until_satisfied(6)
+             |> Workflow.raw_productions(:consumer) == [60]
+    end
+
+    test "binds from a Map leaf exit" do
+      map = Runic.map(fn value -> value * 2 end, name: :mapped)
+      consumer = Runic.step(fn value -> value + 1 end, name: :consumer)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(map)
+        |> Workflow.add(consumer,
+          connections: [[from: {:mapped, :out}, to: :in]]
+        )
+
+      assert workflow
+             |> Workflow.react_until_satisfied([1, 2])
+             |> Workflow.raw_productions(:consumer)
+             |> Enum.sort() == [3, 5]
+    end
+
+    test "binds through Reduce fan-in entry and exit nodes" do
+      producer = Runic.step(fn _input -> [1, 2, 3] end, name: :producer)
+      reduce = Runic.reduce(0, fn value, acc -> value + acc end, name: :sum)
+      consumer = Runic.step(fn value -> value * 10 end, name: :consumer)
+
+      workflow =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(reduce,
+          connections: [[from: {:producer, :out}, to: :items]]
+        )
+        |> Workflow.add(consumer,
+          connections: [[from: {:sum, :result}, to: :in]]
+        )
+
+      for candidate <- [workflow, workflow |> Workflow.build_log() |> Workflow.from_log()] do
+        assert candidate
+               |> Workflow.react_until_satisfied(:start)
+               |> Workflow.raw_productions(:consumer) == [60]
+      end
+    end
+  end
+
+  defp positional_sum_workflow do
+    left =
+      Runic.step(fn input -> input + 1 end,
+        name: :left,
+        outputs: [value: [type: :integer]]
+      )
+
+    right =
+      Runic.step(fn input -> input * 2 end,
+        name: :right,
+        outputs: [value: [type: :integer]]
+      )
+
+    sum =
+      Runic.step(fn left_value, right_value -> left_value + right_value end,
+        name: :sum,
+        inputs: [left: [type: :integer], right: [type: :integer]],
+        invocation: :positional_inputs
+      )
+
+    Workflow.new()
+    |> Workflow.add(left)
+    |> Workflow.add(right)
+    |> Workflow.add(sum,
+      connections: [
+        [from: {:right, :value}, to: :right],
+        [from: {:left, :value}, to: :left]
+      ]
+    )
+  end
+
+  defp logical_inventory(workflow) do
+    workflow
+    |> Workflow.component_graph()
+    |> Multigraph.edges()
+    |> Enum.map(fn edge ->
+      {edge.v1.name, edge.v2.name, Enum.map(edge.properties.connections, &Map.from_struct/1)}
+    end)
+    |> Enum.sort()
+  end
+
+  defp flow_inventory(workflow) do
+    workflow
+    |> Workflow.flow_graph()
+    |> Multigraph.edges()
+    |> Enum.map(fn edge -> {node_identity(edge.v1), node_identity(edge.v2), edge.label} end)
+    |> Enum.sort()
+  end
+
+  defp node_identity(%Join{joins: joins}), do: {:join, joins}
+  defp node_identity(%InputBinding{bindings: bindings}), do: {:binding, bindings}
+  defp node_identity(%Root{}), do: :root
+  defp node_identity(%{name: name}) when not is_nil(name), do: {:component, name}
+  defp node_identity(%{hash: hash}), do: {:node, hash}
+end

--- a/test/workflow/named_connection_test.exs
+++ b/test/workflow/named_connection_test.exs
@@ -7,6 +7,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
 
   alias Runic.Workflow.{
     ComponentAdded,
+    CallContract,
     Connection,
     Fact,
     InputBinding,
@@ -43,8 +44,9 @@ defmodule Runic.Workflow.NamedConnectionTest do
           ]
         )
 
-      assert Workflow.raw_productions(Workflow.react_until_satisfied(workflow, 5), :consumer) ==
-               [21]
+      executed = Workflow.react_until_satisfied(workflow, 5)
+
+      assert Workflow.raw_productions(executed, :consumer) == [21]
 
       refute Enum.any?(Multigraph.vertices(workflow.graph), &match?(%Join{}, &1))
 
@@ -58,8 +60,22 @@ defmodule Runic.Workflow.NamedConnectionTest do
              ] =
                Multigraph.edges(workflow.graph, by: :connects_to)
 
-      assert [%{v2: %InputBinding{}, properties: %{kind: :input_binding}}] =
+      assert [%{v2: %InputBinding{} = binding, properties: %{kind: :input_binding}}] =
                Multigraph.out_edges(workflow.graph, consumer, by: :compiled_for)
+
+      assert [%{v2: %Fact{} = bound_fact}] =
+               Multigraph.out_edges(executed.graph, binding, by: :produced)
+
+      assert {:ok, runnable} = Invokable.prepare(consumer, executed, bound_fact)
+
+      assert [
+               %{
+                 id: "score-binding",
+                 source_port: :payload,
+                 target_port: :score,
+                 selector: [:score]
+               }
+             ] = runnable.invocation.bindings.sources
     end
 
     test "assembles multiple sources in target port order, independent of declaration order" do
@@ -108,8 +124,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
       consumer =
         Runic.step(fn left, right -> left + right end,
           name: :consumer,
-          inputs: [left: [type: :integer], right: [type: :integer]],
-          invocation: :positional_inputs
+          inputs: [left: [type: :integer], right: [type: :integer]]
         )
 
       workflow =
@@ -296,8 +311,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
       consumer =
         Runic.step(fn left, right -> {left, right} end,
           name: :consumer,
-          inputs: [left: [type: :any], right: [type: :any]],
-          invocation: :positional_inputs
+          inputs: [left: [type: :any], right: [type: :any]]
         )
 
       workflow = Workflow.new() |> Workflow.add(producer)
@@ -324,36 +338,44 @@ defmodule Runic.Workflow.NamedConnectionTest do
       end
     end
 
-    test "requires explicit positional invocation for bound multi-input steps" do
+    test "compiles bound multi-input steps as positional without a user invocation option" do
       left = Runic.step(fn input -> input end, name: :left)
       right = Runic.step(fn input -> input end, name: :right)
 
-      ambiguous =
+      sum =
         Runic.step(fn left, right -> left + right end,
-          name: :ambiguous,
+          name: :sum,
           inputs: [left: [type: :any], right: [type: :any]]
         )
 
-      workflow = Workflow.new() |> Workflow.add(left) |> Workflow.add(right)
-
-      assert_raise ArgumentError, ~r/declare invocation: :positional_inputs/, fn ->
-        Workflow.add(workflow, ambiguous,
+      workflow =
+        Workflow.new()
+        |> Workflow.add(left)
+        |> Workflow.add(right)
+        |> Workflow.add(sum,
           connections: [
             [from: {:left, :out}, to: :left],
             [from: {:right, :out}, to: :right]
           ]
         )
-      end
+        |> Workflow.put_run_context(%{_global: %{request_id: "request-1"}})
+
+      refute Map.has_key?(sum, :invocation)
+      assert %CallContract{style: :positional, input_order: [:left, :right]} = sum.call_contract
+
+      assert workflow
+             |> Workflow.react_until_satisfied(5)
+             |> Workflow.raw_productions(:sum) == [10]
     end
 
-    test "input_and_context is explicit and receives runtime context" do
+    test "context/1 compiles input-and-context calling without a user invocation option" do
       producer = Runic.step(fn input -> input + 1 end, name: :producer)
 
       consumer =
-        Runic.step(fn input, context -> input + Map.fetch!(context, :offset) end,
-          name: :consumer,
-          invocation: :input_and_context
-        )
+        Runic.step(fn input -> input + context(:offset) end, name: :consumer)
+
+      assert %CallContract{style: :input_and_context, input_order: [:in]} =
+               consumer.call_contract
 
       workflow =
         Workflow.new()
@@ -509,8 +531,7 @@ defmodule Runic.Workflow.NamedConnectionTest do
     sum =
       Runic.step(fn left_value, right_value -> left_value + right_value end,
         name: :sum,
-        inputs: [left: [type: :integer], right: [type: :integer]],
-        invocation: :positional_inputs
+        inputs: [left: [type: :integer], right: [type: :integer]]
       )
 
     Workflow.new()


### PR DESCRIPTION
## Stack

This is the second PR in the issue #11 implementation stack.

- Base and first slice: #12 (`zw/grouped-replay-correctness`)
- This slice: durable named-port connection contracts, lowering, and deterministic callable compilation

Please review and merge #12 first. This PR intentionally targets its branch so the two slices can be tested together while keeping the replay correction independently reviewable.

## What changed

- add a serializable `Runic.Workflow.Connection` contract for named source and target ports, safe selectors, nested target paths, and deterministic or authored IDs
- validate complete connection groups before graph mutation, including component resolution, port existence, required inputs, exact named-port type compatibility, and overlapping target paths
- lower authored connections into scheduler-visible `InputBinding` nodes, reusing `Join` only for distinct multi-source inputs
- preserve logical `:connects_to` edges separately from compiled `:flow` and `:fan_in` edges, with explicit `component_graph/1` and `flow_graph/1` projections
- persist normalized connections in `ComponentAdded` build events and deterministically reconstruct equivalent graphs during replay
- compile every authored Step into an internal, versioned, data-only `CallContract`
- attach only a compact `Invocation.Plan` containing the call contract to prepared runnables
- materialize the unchanged domain value, ordered positional arguments, named bindings, binding provenance, and runtime/meta/effective context inside `Invokable.execute/2`, after executor and timeout process boundaries
- discard the materialized envelope after the call; completed runnables retain only the compact plan
- keep ordinary zero-, one-, and multi-arity Elixir authoring unchanged; positional arity is inferred deterministically and documented `context/1` expressions compile automatically to input-and-context calls
- remove the proposed public `invocation:` modes and the runtime heuristic that allowed unrelated context to reinterpret an arity-2 positional function
- infer current contracts for pre-contract Step structs whose serialized maps do not contain the new field
- support Rule, Map, and Reduce sources and targets where their compiled entry or exit node is unambiguous
- expose input-binding nodes in DOT, Mermaid, and Cytoscape serializers without treating them as authored components or final component results

## Calling convention

Normal users do not select an invocation mode:

```elixir
Runic.step(fn left, right -> left + right end,
  inputs: [left: [type: :integer], right: [type: :integer]]
)

Runic.step(fn input ->
  call_service(input, context(:api_key))
end)
```

The first compiles to positional arguments. The second is identified from macro metadata and receives the complete input plus prepared context. Plain arity-2 functions no longer implicitly receive context merely because runtime context is populated; that undocumented alpha edge case is intentionally broken.

Internally, scheduling and execution are separated:

```elixir
plan = Invocation.plan(call_contract)

# The runnable crosses executor boundaries with only the compact plan.
runnable = Runnable.with_invocation(runnable, plan)

# This happens in the final execution process.
invocation = Invocation.materialize(plan, fact.value, causal_context)
result = Invocation.call(invocation, step.work)
```

## Deliberate boundaries

- ambiguous composite exits are rejected instead of guessed
- multi-port non-Step targets are rejected until their invocation semantics are explicit
- selectors and target paths are data-only atom, string, or non-negative integer segments; executable accessors and coercion callbacks are not accepted
- invocation plans live on prepared runnables rather than in domain fact values; runtime context remains outside authored build logs and ordinary result facts
- rich invocation views are process-local execution data, not scheduled or retained runnable state

## Memory validation

A one-off OTP 28 cross-process probe compared the prior materialized runnable with the compact plan using large heap terms and runtime context:

- 100k-integer-list fact: compact plan adds 80 bytes in the sender and 0 bytes in the receiving process
- 10k nested map/list fact: compact plan adds 0 bytes in the receiving process
- 100k-list runtime context: compact plan adds 0 bytes in the receiving process
- Task executor with a 100k-integer-list fact: baseline 6.36 MiB, eager materialized envelope 10.98 MiB, compact plan 6.36 MiB

The remaining plan overhead is payload-independent and measured at about 0.07–0.08 microseconds per single-input preparation in this probe. Materialization still creates the rich contract views, but only after the final process boundary and only for the duration of the work call.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- focused invocation and named-connection suites — 26 tests, 0 failures
- `mix test` — 55 doctests, 1363 tests, 0 failures, 13 skipped
- `mix docs` — generated successfully; only existing hidden-event reference warnings remain
- `git diff --check`

The repository has no `mix precommit` task or alias, so the equivalent available gates above were run directly.
