### PR TITLE
Preserve durable nested workflow boundaries

### DIFF
--- a/guides/cheatsheet.md
+++ b/guides/cheatsheet.md
@@ -395,6 +395,58 @@ Zero- and one-arity steps receive zero or one argument. Multi-arity steps receiv
 positional values in declared input-port order. Runtime context is requested
 with `context/1`; an ordinary arity-two function is always a two-input function.
 
+### Nested Workflow Components
+
+A workflow becomes an authored nested component when it declares boundary
+`input_ports`, `output_ports`, or both. Add it with the same `connections:` API
+used for ordinary components:
+
+```elixir
+inner = Runic.step(fn value -> value * 2 end,
+  name: :inner,
+  inputs: [in: [type: :integer]],
+  outputs: [out: [type: :integer]]
+)
+
+child =
+  Workflow.new(
+    name: :double,
+    input_ports: [in: [type: :integer]],
+    output_ports: [out: [type: :integer, from: :inner]]
+  )
+  |> Workflow.add(inner)
+
+source = Runic.step(fn input -> input + 1 end,
+  name: :source,
+  outputs: [out: [type: :integer]]
+)
+
+sink = Runic.step(fn value -> value end,
+  name: :sink,
+  inputs: [value: [type: :integer]]
+)
+
+parent =
+  Workflow.new(name: :parent)
+  |> Workflow.add(source)
+  |> Workflow.add(child,
+    connections: [[from: {:source, :out}, to: :in]]
+  )
+  |> Workflow.add(sink,
+    connections: [[from: {:double, :out}, to: :value]]
+  )
+```
+
+The boundary name is the child workflow's name. Each downstream-readable output
+port needs `from: internal_component_name` so Runic can associate the public
+port with one compiled internal output. Output declarations without `:from`
+remain useful as contracts, but cannot be named connection sources.
+
+The parent build log stores the bounded child as one versioned, recursively
+replayable definition. Runtime facts, hooks, run context, and runnable state are
+not part of that construction definition. A workflow without boundary ports
+keeps the existing inline composition behavior.
+
 ## Evaluating Workflows
 
 ### Basic Execution
@@ -622,6 +674,7 @@ Workflow.add(workflow, merge_step, to: [:a, :b, :c])
 | Create workflow | `Runic.workflow(steps: [...], rules: [...])` |
 | Add component | `Workflow.add(workflow, component, to: parent)` |
 | Bind named ports | `Workflow.add(workflow, component, connections: [...])` |
+| Add nested workflow | Declare child boundary ports, then use `Workflow.add/3` |
 | Get authored graph | `Workflow.component_graph(workflow)` |
 | Get compiled flow graph | `Workflow.flow_graph(workflow)` |
 | Run one cycle | `Workflow.react(workflow, input)` |

--- a/guides/usage-rules.md
+++ b/guides/usage-rules.md
@@ -333,6 +333,59 @@ flowchart LR
 Use these projections for topology inspection. Do not infer authored components
 from every scheduler-visible node in the full multigraph.
 
+### Prefer: Explicit Boundaries for Reusable Workflows
+
+Declare boundary ports when a child workflow should behave as one authored,
+durable component inside a parent:
+
+```elixir
+child =
+  Workflow.new(
+    name: :normalize_order,
+    input_ports: [order: [type: :map]],
+    output_ports: [normalized: [type: :map, from: :normalize]]
+  )
+  |> Workflow.add(
+    Runic.step(&normalize/1,
+      name: :normalize,
+      inputs: [order: [type: :map]],
+      outputs: [normalized: [type: :map]]
+    )
+  )
+
+parent = Workflow.add(parent, child,
+  connections: [[from: {:source, :order}, to: :order]]
+)
+```
+
+Declaring either `input_ports` or `output_ports` makes the child an explicit
+boundary. Its name, stable hash, boundary contracts, and ordered build log are
+stored as one nested definition in the parent. This is the right model when the
+child has a public contract, should remain identifiable in the component graph,
+or must replay as a unit.
+
+Use `from: internal_component_name` on every output that must feed a downstream
+named connection. Runic does not guess among internal productions. A contract-only
+output without `:from` is valid, but cannot be resolved as a connection source.
+
+Leave boundary ports unset for internal compiler workflows that should retain
+Runic's existing inline composition behavior. Do not add placeholder ports just
+to force nesting; a boundary is an authored API and should be stable enough to
+persist and reconnect.
+
+```mermaid
+flowchart LR
+  S[Parent source] -->|logical port connection| C[Child workflow component]
+  S1[Source invokable] --> B[InputBinding]
+  B --> I[Child internal entry]
+  I --> O[Child internal output]
+  C -. output port ownership .-> O
+  O --> D[Downstream binding]
+```
+
+The parent stores construction data, not execution state. Runtime facts, hooks,
+run context, and runnable state remain outside the nested definition.
+
 ### Map-Reduce Pattern
 
 ```elixir
@@ -438,6 +491,10 @@ Named connections are normalized into `%Runic.Workflow.Connection{}` data in
 the build log. A `build_log/1` and `from_log/1` round trip therefore rebuilds
 both the logical component connections and their compiled input-binding flow.
 
+Explicitly bounded child workflows are persisted recursively as versioned nested
+definitions. Replaying the parent rebuilds each child independently before
+reconnecting its boundary; child runtime state is never serialized as construction data.
+
 ## Debugging Tips
 
 1. **Visualize with Mermaid**:
@@ -478,6 +535,7 @@ both the logical component connections and their compiled input-binding flow.
 | **Always pin** | `^variable` for runtime values |
 | **Always name** | Components for debugging |
 | **Bind data with** | `connections:` for named ports, selectors, and target paths |
+| **Compose reusable workflows with** | Explicit boundary ports and named connections |
 | **Inspect topology with** | `component_graph/1` or `flow_graph/1`, depending on intent |
 | **Extract with** | `raw_productions/1`, not graph access |
 | **Serialize with** | `build_log/1` and `from_log/1` |

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -321,6 +321,11 @@ defmodule Runic.Workflow do
   @doc """
   Constructs a new Runic Workflow with the given name or parameters.
 
+  A workflow that declares `:input_ports`, `:output_ports`, or both is treated
+  as an authored boundary when added to another workflow. Boundary output ports
+  use `from: component_name` to identify the internal production exposed to
+  downstream named connections.
+
   ## Examples
 
       iex> alias Runic.Workflow
@@ -693,6 +698,34 @@ defmodule Runic.Workflow do
   is the only internal production attributed to the child boundary. Output
   ports without `:from` remain valid for contract-only use but are not guessed
   when compiling downstream named connections.
+
+      child =
+        Workflow.new(
+          name: :double,
+          input_ports: [in: [type: :integer]],
+          output_ports: [out: [type: :integer, from: :inner]]
+        )
+        |> Workflow.add(
+          Runic.step(fn value -> value * 2 end,
+            name: :inner,
+            inputs: [in: [type: :integer]],
+            outputs: [out: [type: :integer]]
+          )
+        )
+
+      parent =
+        Workflow.new(name: :parent)
+        |> Workflow.add(source)
+        |> Workflow.add(child,
+          connections: [[from: {:source, :out}, to: :in]]
+        )
+
+  The parent build log stores one versioned definition for the child. Runtime
+  facts, run context, hooks, and runnable state are excluded. Workflows without
+  declared boundary ports retain inline composition behavior.
+
+  See the [Cheatsheet](cheatsheet.html#nested-workflow-components) and
+  [Usage Rules](usage-rules.html#prefer-explicit-boundaries-for-reusable-workflows).
   """
   def add(%__MODULE__{} = workflow, component, opts \\ []) do
     case Keyword.fetch(opts, :connections) do

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -1310,11 +1310,13 @@ defmodule Runic.Workflow do
         name: component.name,
         to: durable_parent_ref(parent),
         connections: connections,
+        input_ports: declared_ports(component, :inputs),
+        output_ports: declared_ports(component, :outputs),
         workflow_definition: workflow_definition,
         hash: Map.get(component, :hash),
         # Backward compatibility: also set source/bindings for old deserialization
         source: if(workflow_definition, do: nil, else: Component.source(component)),
-        bindings: if(closure, do: closure.bindings, else: %{})
+        bindings: if(closure, do: closure.bindings, else: Map.get(component, :bindings, %{}))
       }
     ]
   end
@@ -1324,6 +1326,12 @@ defmodule Runic.Workflow do
   end
 
   defp workflow_definition(_component), do: nil
+
+  defp declared_ports(component, field) when is_map(component) do
+    if Map.has_key?(component, field), do: Map.get(component, field)
+  end
+
+  defp declared_ports(_component, _field), do: nil
 
   defp workflow_boundary?(%__MODULE__{input_ports: input_ports, output_ports: output_ports}),
     do: not is_nil(input_ports) or not is_nil(output_ports)
@@ -1348,31 +1356,7 @@ defmodule Runic.Workflow do
     do: do_append_build_log(workflow, component, durable_parent_ref(parent))
 
   defp do_append_build_log(%__MODULE__{build_log: bl} = workflow, component, parent) do
-    # Use new closure field if available, otherwise fall back to old format
-    event =
-      case Map.get(component, :closure) do
-        %Closure{} = closure ->
-          %ComponentAdded{
-            closure: closure,
-            name: component.name,
-            to: parent,
-            hash: Map.get(component, :hash)
-          }
-
-        nil ->
-          workflow_definition = workflow_definition(component)
-
-          # Backward compatibility: non-workflow components without a closure
-          # continue to use the old source + bindings format.
-          %ComponentAdded{
-            source: if(workflow_definition, do: nil, else: Component.source(component)),
-            name: component.name,
-            to: parent,
-            workflow_definition: workflow_definition,
-            hash: Map.get(component, :hash),
-            bindings: Map.get(component, :bindings, %{})
-          }
-      end
+    [event] = build_events(component, parent, nil)
 
     %__MODULE__{
       workflow
@@ -1736,6 +1720,7 @@ defmodule Runic.Workflow do
     component =
       component
       |> Map.put(:name, event.name)
+      |> restore_declared_ports(event)
 
     # Restore original hash if stored — ensures hash stability across rebuilds
     if event.hash do
@@ -1743,6 +1728,18 @@ defmodule Runic.Workflow do
     else
       component
     end
+  end
+
+  defp restore_declared_ports(component, event) do
+    component
+    |> restore_declared_port(:inputs, Map.get(event, :input_ports))
+    |> restore_declared_port(:outputs, Map.get(event, :output_ports))
+  end
+
+  defp restore_declared_port(component, _field, nil), do: component
+
+  defp restore_declared_port(component, field, ports) do
+    if Map.has_key?(component, field), do: Map.put(component, field, ports), else: component
   end
 
   # Backward compatibility: evaluate source with old __caller_context__ approach

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -236,6 +236,7 @@ defmodule Runic.Workflow do
   alias Runic.Workflow.Invokable
   alias Runic.Workflow.ComponentAdded
   alias Runic.Workflow.Connection
+  alias Runic.Workflow.Definition
   alias Runic.Workflow.InputBinding
   alias Runic.Workflow.CallContract
   alias Runic.Workflow.ComponentRemoved
@@ -679,6 +680,19 @@ defmodule Runic.Workflow do
   See `Runic.Workflow.Connection`, the
   [Cheatsheet](cheatsheet.html#named-port-connections), and the
   [Usage Rules](usage-rules.html#prefer-connections-for-data-binding).
+
+  ## Nested Workflow Boundaries
+
+  A workflow that declares `input_ports`, `output_ports`, or both is treated as
+  an authored nested component. Its boundary ports and child build log are
+  stored as one versioned definition in the parent build log rather than
+  flattening the child's construction events into the parent.
+
+  An output port with `from: component_name` is compiled to that internal
+  component's output node. It can be used as a downstream named connection and
+  is the only internal production attributed to the child boundary. Output
+  ports without `:from` remain valid for contract-only use but are not guessed
+  when compiling downstream named connections.
   """
   def add(%__MODULE__{} = workflow, component, opts \\ []) do
     case Keyword.fetch(opts, :connections) do
@@ -688,6 +702,8 @@ defmodule Runic.Workflow do
   end
 
   defp add_to_parent(%__MODULE__{} = workflow, component, opts) do
+    component = if workflow_boundary?(component), do: ensure_component(component), else: component
+
     case opts[:to] do
       nil ->
         # If no parent is specified, we assume the component is a root step
@@ -766,7 +782,7 @@ defmodule Runic.Workflow do
     workflow =
       workflow
       |> add_step(binding_parent, input_binding)
-      |> then(&Component.connect(component, input_binding, &1))
+      |> then(&connect_component(&1, component, input_binding))
       |> draw_connection(component, input_binding, :compiled_for,
         properties: %{
           kind: :input_binding,
@@ -780,6 +796,10 @@ defmodule Runic.Workflow do
     else
       workflow
     end
+  end
+
+  defp ensure_component(%__MODULE__{hash: nil} = workflow) do
+    %{workflow | hash: Component.hash(workflow)}
   end
 
   defp ensure_component(%{__struct__: _} = component) do
@@ -805,7 +825,7 @@ defmodule Runic.Workflow do
     %{
       connection: connection,
       source_component: source_component,
-      source_node: output_node!(workflow, source_component),
+      source_node: output_node!(workflow, source_component, connection.source_port),
       source_outputs: source_outputs,
       source_port_index: source_port_index
     }
@@ -827,6 +847,31 @@ defmodule Runic.Workflow do
   end
 
   defp resolve_component_ref!(workflow, name), do: get_component!(workflow, name)
+
+  defp output_node!(workflow, %__MODULE__{} = child, source_port) do
+    output_edges =
+      Multigraph.out_edges(workflow.graph, child,
+        by: :component_of,
+        where: fn edge ->
+          edge.properties[:kind] == :output and source_port in edge.properties[:ports]
+        end
+      )
+
+    case output_edges do
+      [%{v2: output_node}] ->
+        output_node
+
+      [] ->
+        raise ArgumentError,
+              "nested workflow #{inspect(child.name)} has no compiled output node for port #{inspect(source_port)}"
+
+      edges ->
+        raise ArgumentError,
+              "nested workflow #{inspect(child.name)} has #{length(edges)} compiled output nodes for port #{inspect(source_port)}"
+    end
+  end
+
+  defp output_node!(workflow, component, _source_port), do: output_node!(workflow, component)
 
   defp output_node!(workflow, %Rule{} = rule) do
     Map.fetch!(workflow.graph.vertices, rule.reaction_hash)
@@ -854,7 +899,7 @@ defmodule Runic.Workflow do
   end
 
   defp output_node_from_ownership!(workflow, component) do
-    preferred_kinds = [:reaction, :leaf, :fan_in, :accumulator, :step]
+    preferred_kinds = [:output, :reaction, :leaf, :fan_in, :accumulator, :step]
 
     edges =
       workflow.graph
@@ -1043,7 +1088,7 @@ defmodule Runic.Workflow do
     case {component, parent} do
       {%{__struct__: _struct}, %Root{}} ->
         if Components.component?(component) do
-          workflow = Component.connect(component, parent, workflow)
+          workflow = connect_component(workflow, component, parent)
 
           if should_log do
             append_build_log(workflow, component, parent)
@@ -1061,8 +1106,8 @@ defmodule Runic.Workflow do
           validate_ports(component, parent, opts)
 
           workflow =
-            component
-            |> Component.connect(parent, workflow)
+            workflow
+            |> connect_component(component, parent)
             |> maybe_draw_connects_to(component, parent)
 
           if should_log do
@@ -1092,6 +1137,57 @@ defmodule Runic.Workflow do
     end
 
     transmuted
+  end
+
+  defp connect_component(
+         %__MODULE__{} = workflow,
+         %__MODULE__{input_ports: input_ports, output_ports: output_ports} = child,
+         parent
+       )
+       when not is_nil(input_ports) or not is_nil(output_ports) do
+    parent_build_log = workflow.build_log
+
+    %__MODULE__{} = workflow = Component.connect(child, parent, workflow)
+
+    workflow = %{
+      workflow
+      | build_log: parent_build_log,
+        graph: Multigraph.add_vertex(workflow.graph, child)
+    }
+
+    workflow
+    |> register_component(child)
+    |> register_workflow_outputs(child)
+  end
+
+  defp connect_component(%__MODULE__{} = workflow, component, parent) do
+    Component.connect(component, parent, workflow)
+  end
+
+  defp register_workflow_outputs(workflow, %__MODULE__{output_ports: output_ports} = child) do
+    outputs =
+      for {port, opts} <- output_ports || [],
+          {:ok, source_name} <- [Keyword.fetch(opts, :from)] do
+        source_component = get_component!(workflow, source_name)
+        output_node = output_node!(workflow, source_component)
+        {output_node, port, source_name}
+      end
+
+    outputs
+    |> Enum.group_by(fn {output_node, _port, _source_name} ->
+      Components.vertex_id_of(output_node)
+    end)
+    |> Enum.reduce(workflow, fn {_output_hash, grouped_outputs}, acc ->
+      [{output_node, _port, _source_name} | _] = grouped_outputs
+
+      draw_connection(acc, child, output_node, :component_of,
+        properties: %{
+          kind: :output,
+          ports: Enum.map(grouped_outputs, &elem(&1, 1)),
+          sources: Enum.map(grouped_outputs, &elem(&1, 2))
+        }
+      )
+    end)
   end
 
   defp validate_ports(consumer, parents, opts) when is_list(parents) do
@@ -1185,6 +1281,7 @@ defmodule Runic.Workflow do
       rebuilt = Workflow.apply_events(Workflow.new(), events)
   """
   def add_with_events(%__MODULE__{} = workflow, component, opts \\ []) do
+    component = if workflow_boundary?(component), do: ensure_component(component), else: component
     to = opts[:to]
 
     connections =
@@ -1205,6 +1302,7 @@ defmodule Runic.Workflow do
 
   defp build_events(component, parent, connections) do
     closure = Map.get(component, :closure)
+    workflow_definition = workflow_definition(component)
 
     [
       %ComponentAdded{
@@ -1212,13 +1310,25 @@ defmodule Runic.Workflow do
         name: component.name,
         to: durable_parent_ref(parent),
         connections: connections,
+        workflow_definition: workflow_definition,
         hash: Map.get(component, :hash),
         # Backward compatibility: also set source/bindings for old deserialization
-        source: Component.source(component),
+        source: if(workflow_definition, do: nil, else: Component.source(component)),
         bindings: if(closure, do: closure.bindings, else: %{})
       }
     ]
   end
+
+  defp workflow_definition(%__MODULE__{} = workflow) do
+    if workflow_boundary?(workflow), do: Definition.from_workflow(workflow)
+  end
+
+  defp workflow_definition(_component), do: nil
+
+  defp workflow_boundary?(%__MODULE__{input_ports: input_ports, output_ports: output_ports}),
+    do: not is_nil(input_ports) or not is_nil(output_ports)
+
+  defp workflow_boundary?(_component), do: false
 
   defp durable_parent_ref(parents) when is_list(parents),
     do: Enum.map(parents, &durable_parent_ref/1)
@@ -1250,11 +1360,15 @@ defmodule Runic.Workflow do
           }
 
         nil ->
-          # Backward compatibility: use old source + bindings format
+          workflow_definition = workflow_definition(component)
+
+          # Backward compatibility: non-workflow components without a closure
+          # continue to use the old source + bindings format.
           %ComponentAdded{
-            source: Component.source(component),
+            source: if(workflow_definition, do: nil, else: Component.source(component)),
             name: component.name,
             to: parent,
+            workflow_definition: workflow_definition,
             hash: Map.get(component, :hash),
             bindings: Map.get(component, :bindings, %{})
           }
@@ -1598,8 +1712,13 @@ defmodule Runic.Workflow do
   defp component_from_added(
          %ComponentAdded{source: source, bindings: bindings, closure: closure} = event
        ) do
+    workflow_definition = Map.get(event, :workflow_definition)
+
     component =
       cond do
+        match?(%Definition{}, workflow_definition) ->
+          Definition.rebuild(workflow_definition)
+
         # New format: use closure if available
         not is_nil(closure) ->
           {comp, _} = Closure.eval(closure)
@@ -1611,7 +1730,7 @@ defmodule Runic.Workflow do
 
         # Fallback: shouldn't happen
         true ->
-          raise "ComponentAdded event has neither closure nor source"
+          raise "ComponentAdded event has no reconstructable component definition"
       end
 
     component =

--- a/lib/workflow/component_added.ex
+++ b/lib/workflow/component_added.ex
@@ -1,12 +1,17 @@
 defmodule Runic.Workflow.ComponentAdded do
-  # To be used as a serializable event log for rebuilding workflows from logs
+  @moduledoc """
+  Serializable construction event used to rebuild a workflow from its log.
+
+  Executable components use `closure`; nested workflows use a versioned
+  `workflow_definition` that retains their boundary ports and child build log.
+  The `source` and `bindings` fields remain as a compatibility path for older
+  component events.
+  """
 
   alias Runic.Closure
 
   @derive {Inspect, only: [:name, :closure]}
 
-  # New format uses :closure field (fully serializable)
-  # Old format uses :source + :bindings with __caller_context__ (deprecated)
   @type t :: %__MODULE__{
           name: String.t() | atom(),
           closure: Closure.t() | nil,
@@ -14,6 +19,7 @@ defmodule Runic.Workflow.ComponentAdded do
           bindings: map(),
           to: term(),
           connections: list(Runic.Workflow.Connection.t()) | nil,
+          workflow_definition: Runic.Workflow.Definition.t() | nil,
           hash: term()
         }
 
@@ -25,6 +31,7 @@ defmodule Runic.Workflow.ComponentAdded do
     :bindings,
     :to,
     :connections,
+    :workflow_definition,
     :hash
   ]
 

--- a/lib/workflow/component_added.ex
+++ b/lib/workflow/component_added.ex
@@ -4,6 +4,8 @@ defmodule Runic.Workflow.ComponentAdded do
 
   Executable components use `closure`; nested workflows use a versioned
   `workflow_definition` that retains their boundary ports and child build log.
+  `input_ports` and `output_ports` retain contracts applied outside the source
+  expression that originally constructed an executable component.
   The `source` and `bindings` fields remain as a compatibility path for older
   component events.
   """
@@ -19,6 +21,8 @@ defmodule Runic.Workflow.ComponentAdded do
           bindings: map(),
           to: term(),
           connections: list(Runic.Workflow.Connection.t()) | nil,
+          input_ports: keyword() | nil,
+          output_ports: keyword() | nil,
           workflow_definition: Runic.Workflow.Definition.t() | nil,
           hash: term()
         }
@@ -31,6 +35,8 @@ defmodule Runic.Workflow.ComponentAdded do
     :bindings,
     :to,
     :connections,
+    :input_ports,
+    :output_ports,
     :workflow_definition,
     :hash
   ]

--- a/lib/workflow/definition.ex
+++ b/lib/workflow/definition.ex
@@ -1,0 +1,89 @@
+defmodule Runic.Workflow.Definition do
+  @moduledoc """
+  Durable construction data for a workflow used as a nested component.
+
+  A nested workflow cannot be reconstructed from its name and component
+  registry alone. Its boundary ports and ordered build events are required to
+  recreate both the internal graph and the boundary lowering. This struct is
+  stored inside the parent workflow's `%Runic.Workflow.ComponentAdded{}` event
+  and can itself contain nested workflow definitions recursively.
+
+  Runtime facts, run context, hooks, and runnable state are intentionally not
+  part of this construction definition.
+
+  A workflow is treated as an authored nested boundary when it declares
+  `input_ports`, `output_ports`, or both. Internal compiler workflows without
+  boundary ports retain their existing composition behavior.
+  """
+
+  alias Runic.Component
+  alias Runic.Workflow
+
+  @version 1
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          name: String.t() | atom(),
+          hash: term(),
+          input_ports: keyword() | nil,
+          output_ports: keyword() | nil,
+          build_log: list(struct())
+        }
+
+  @enforce_keys [:version, :name, :hash, :build_log]
+  defstruct [:version, :name, :hash, :input_ports, :output_ports, :build_log]
+
+  @doc false
+  @spec from_workflow(Workflow.t()) :: t()
+  def from_workflow(%{__struct__: Workflow} = workflow) do
+    %__MODULE__{
+      version: @version,
+      name: workflow.name,
+      hash: workflow.hash || Component.hash(workflow),
+      input_ports: workflow.input_ports,
+      output_ports: workflow.output_ports,
+      build_log: Workflow.build_log(workflow)
+    }
+    |> validate!()
+  end
+
+  @doc false
+  @spec rebuild(t()) :: Workflow.t()
+  def rebuild(%__MODULE__{version: @version} = definition) do
+    definition = validate!(definition)
+
+    [
+      name: definition.name,
+      hash: definition.hash,
+      input_ports: definition.input_ports,
+      output_ports: definition.output_ports
+    ]
+    |> Workflow.new()
+    |> Workflow.apply_events(definition.build_log)
+  end
+
+  def rebuild(%__MODULE__{version: version}) do
+    raise ArgumentError,
+          "unsupported nested workflow definition version: #{inspect(version)}"
+  end
+
+  defp validate!(%__MODULE__{} = definition) do
+    unless is_atom(definition.name) or is_binary(definition.name) do
+      raise ArgumentError,
+            "nested workflow definition name must be an atom or string, got: #{inspect(definition.name)}"
+    end
+
+    unless ports?(definition.input_ports) and ports?(definition.output_ports) do
+      raise ArgumentError, "nested workflow definition ports must be keyword lists or nil"
+    end
+
+    unless is_list(definition.build_log) and Enum.all?(definition.build_log, &is_struct/1) do
+      raise ArgumentError, "nested workflow definition build log must contain event structs"
+    end
+
+    definition
+  end
+
+  defp ports?(nil), do: true
+  defp ports?(ports), do: Keyword.keyword?(ports)
+end

--- a/lib/workflow/definition.ex
+++ b/lib/workflow/definition.ex
@@ -14,6 +14,15 @@ defmodule Runic.Workflow.Definition do
   A workflow is treated as an authored nested boundary when it declares
   `input_ports`, `output_ports`, or both. Internal compiler workflows without
   boundary ports retain their existing composition behavior.
+
+  Output ports with `from: component_name` retain the ownership needed for a
+  parent to resolve downstream named connections after replay. Contract-only
+  outputs without `:from` are preserved but are not resolved by inference.
+
+  See the [Cheatsheet](cheatsheet.html#nested-workflow-components) and
+  [Usage Rules](usage-rules.html#prefer-explicit-boundaries-for-reusable-workflows)
+  for the public construction API. This definition is an internal persistence
+  contract and is not normally constructed directly.
   """
 
   alias Runic.Component

--- a/mix.exs
+++ b/mix.exs
@@ -86,6 +86,7 @@ defmodule Runic.MixProject do
         ],
         Internal: [
           Runic.Workflow.Fact,
+          Runic.Workflow.Definition,
           Runic.Workflow.FanOut,
           Runic.Workflow.FanIn,
           Runic.Workflow.Runnable,

--- a/test/workflow/composite_connection_boundary_test.exs
+++ b/test/workflow/composite_connection_boundary_test.exs
@@ -1,0 +1,334 @@
+defmodule Runic.Workflow.CompositeConnectionBoundaryTest do
+  use ExUnit.Case, async: true
+
+  require Runic
+
+  alias Runic.Workflow
+
+  alias Runic.Workflow.{
+    ComponentAdded,
+    Connection,
+    Definition,
+    InputBinding,
+    Join,
+    Root
+  }
+
+  describe "durable nested workflow boundaries" do
+    test "round-trips a named input binding without flattening the child build log" do
+      source = Runic.step(fn input -> input + 1 end, name: :source)
+      inner = Runic.step(fn value -> value * 10 end, name: :inner)
+
+      child =
+        Workflow.new(
+          name: :child,
+          input_ports: [in: [type: :integer]],
+          output_ports: [out: [type: :integer, from: :inner]]
+        )
+        |> Workflow.add(inner)
+
+      {parent, source_events} =
+        Workflow.add_with_events(Workflow.new(name: :parent), source)
+
+      {original, child_events} =
+        Workflow.add_with_events(parent, child,
+          connections: [[id: :child_input, from: {:source, :out}, to: :in]]
+        )
+
+      assert Workflow.build_log(original) == source_events ++ child_events
+
+      serialized_log =
+        original
+        |> Workflow.build_log()
+        |> :erlang.term_to_binary()
+        |> :erlang.binary_to_term()
+
+      assert [
+               %ComponentAdded{name: :source},
+               %ComponentAdded{
+                 name: :child,
+                 source: nil,
+                 connections: [
+                   %Connection{id: :child_input, target: :child, target_port: :in}
+                 ],
+                 workflow_definition: %Definition{
+                   version: 1,
+                   name: :child,
+                   input_ports: [in: [type: :integer]],
+                   output_ports: [out: [type: :integer, from: :inner]],
+                   build_log: [%ComponentAdded{name: :inner}]
+                 }
+               }
+             ] = serialized_log
+
+      rebuilt = Workflow.from_log(serialized_log)
+
+      assert component_inventory(original) == component_inventory(rebuilt)
+      assert flow_inventory(original) == flow_inventory(rebuilt)
+
+      for candidate <- [original, rebuilt] do
+        assert %Workflow{
+                 name: :child,
+                 input_ports: [in: [type: :integer]],
+                 output_ports: [out: [type: :integer, from: :inner]]
+               } = Workflow.get_component(candidate, :child)
+
+        assert candidate
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.results([:child, :inner]) == %{child: 60, inner: 60}
+
+        assert Enum.count(
+                 Multigraph.vertices(Workflow.flow_graph(candidate)),
+                 &match?(%InputBinding{}, &1)
+               ) == 1
+      end
+    end
+
+    test "retains whole-value child workflow connections across replay" do
+      source = Runic.step(fn input -> input + 1 end, name: :source)
+      inner = Runic.step(fn value -> value * 10 end, name: :inner)
+
+      child =
+        Workflow.new(
+          name: :child,
+          input_ports: [in: [type: :any]],
+          output_ports: [out: [type: :any, from: :inner]]
+        )
+        |> Workflow.add(inner)
+
+      original =
+        Workflow.new(name: :parent)
+        |> Workflow.add(source)
+        |> Workflow.add(child, to: :source)
+
+      rebuilt = original |> Workflow.build_log() |> Workflow.from_log()
+
+      assert component_inventory(original) == component_inventory(rebuilt)
+      assert flow_inventory(original) == flow_inventory(rebuilt)
+
+      for candidate <- [original, rebuilt] do
+        assert %Workflow{name: :child} = Workflow.get_component(candidate, :child)
+
+        assert candidate
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:inner) == [60]
+      end
+    end
+
+    test "routes a declared child output without exposing the downstream binder as child output" do
+      inner =
+        Runic.step(
+          fn value -> %{out: value * 10, mirrored: value * 10} end,
+          name: :inner
+        )
+
+      consumer = Runic.step(fn value -> value + 1 end, name: :consumer)
+
+      child =
+        Workflow.new(
+          name: :child,
+          input_ports: [in: [type: :integer]],
+          output_ports: [
+            out: [type: :integer, from: :inner],
+            mirrored: [type: :integer, from: :inner]
+          ]
+        )
+        |> Workflow.add(inner)
+
+      original =
+        Workflow.new(name: :parent)
+        |> Workflow.add(child)
+        |> Workflow.add(consumer, connections: [[from: {:child, :out}, to: :in]])
+
+      rebuilt = original |> Workflow.build_log() |> Workflow.from_log()
+
+      assert component_inventory(original) == component_inventory(rebuilt)
+      assert flow_inventory(original) == flow_inventory(rebuilt)
+
+      for candidate <- [original, rebuilt] do
+        executed = Workflow.react_until_satisfied(candidate, 5)
+
+        assert Workflow.results(executed, [:child, :inner, :consumer]) == %{
+                 child: %{out: 50, mirrored: 50},
+                 inner: %{out: 50, mirrored: 50},
+                 consumer: 51
+               }
+
+        assert Workflow.raw_productions(executed, :child) == [%{out: 50, mirrored: 50}]
+
+        assert [
+                 %{
+                   properties: %{
+                     kind: :output,
+                     ports: [:out, :mirrored],
+                     sources: [:inner, :inner]
+                   }
+                 }
+               ] =
+                 Multigraph.out_edges(candidate.graph, Workflow.get_component(candidate, :child),
+                   by: :component_of
+                 )
+
+        assert Enum.count(
+                 Multigraph.vertices(Workflow.flow_graph(candidate)),
+                 &match?(%InputBinding{}, &1)
+               ) == 1
+      end
+    end
+
+    test "rejects unsupported nested definition versions" do
+      inner = Runic.step(fn value -> value end, name: :inner)
+      child = Workflow.new(name: :child) |> Workflow.add(inner)
+      definition = Definition.from_workflow(child)
+
+      assert_raise ArgumentError, "unsupported nested workflow definition version: 2", fn ->
+        Definition.rebuild(%{definition | version: 2})
+      end
+    end
+  end
+
+  describe "stateful and coordinated composite boundaries" do
+    test "binds into an Accumulator and preserves replayed state production" do
+      source = Runic.step(fn input -> input + 1 end, name: :source)
+
+      accumulator =
+        Runic.accumulator(0, fn value, state -> value + state end,
+          name: :counter,
+          inputs: [in: [type: :integer]],
+          outputs: [state: [type: :integer]]
+        )
+
+      assert_replayed_output(
+        Workflow.new(name: :accumulator_parent)
+        |> Workflow.add(source)
+        |> Workflow.add(accumulator, connections: [[from: {:source, :out}, to: :in]]),
+        5,
+        :counter,
+        [0, 6]
+      )
+    end
+
+    test "binds into a StateMachine and preserves replayed state transitions" do
+      source = Runic.step(fn input -> input + 1 end, name: :source)
+
+      state_machine =
+        Runic.state_machine(
+          name: :counter,
+          init: 0,
+          reducer: fn value, state -> value + state end,
+          inputs: [event: [type: :integer]],
+          outputs: [state: [type: :integer]]
+        )
+
+      assert_replayed_output(
+        Workflow.new(name: :state_machine_parent)
+        |> Workflow.add(source)
+        |> Workflow.add(state_machine,
+          connections: [[from: {:source, :out}, to: :event]]
+        ),
+        5,
+        :counter,
+        [0, 6]
+      )
+    end
+
+    test "binds into a map-linked Reduce and preserves fan-in coordination" do
+      source = Runic.step(fn _input -> [1, 2, 3] end, name: :source)
+      map = Runic.map(fn value -> value * 2 end, name: :double)
+      reduce = Runic.reduce(0, fn value, acc -> value + acc end, name: :sum, map: :double)
+
+      original =
+        Workflow.new(name: :map_reduce_parent)
+        |> Workflow.add(source)
+        |> Workflow.add(map, connections: [[from: {:source, :out}, to: :items]])
+        |> Workflow.add(reduce, to: :double)
+
+      rebuilt = original |> Workflow.build_log() |> Workflow.from_log()
+
+      assert component_inventory(original) == component_inventory(rebuilt)
+      assert flow_inventory(original) == flow_inventory(rebuilt)
+
+      for candidate <- [original, rebuilt] do
+        assert candidate
+               |> Workflow.react_until_satisfied(:start)
+               |> Workflow.raw_productions(:sum) == [12]
+
+        assert Enum.count(Multigraph.edges(candidate.graph, by: :fan_in)) == 1
+      end
+    end
+  end
+
+  defp assert_replayed_output(original, input, component_name, expected) do
+    rebuilt = original |> Workflow.build_log() |> Workflow.from_log()
+
+    assert component_inventory(original) == component_inventory(rebuilt)
+    assert flow_inventory(original) == flow_inventory(rebuilt)
+
+    for candidate <- [original, rebuilt] do
+      actual =
+        candidate
+        |> Workflow.react_until_satisfied(input)
+        |> Workflow.raw_productions(component_name)
+        |> Enum.sort()
+
+      assert actual == expected
+    end
+  end
+
+  defp component_inventory(workflow) do
+    workflow
+    |> Workflow.component_graph()
+    |> Multigraph.edges()
+    |> Enum.map(fn edge ->
+      connections =
+        edge.properties
+        |> Map.get(:connections, [])
+        |> Enum.map(&Map.from_struct/1)
+
+      {
+        node_identity(workflow, edge.v1),
+        node_identity(workflow, edge.v2),
+        edge.label,
+        connections
+      }
+    end)
+    |> Enum.sort()
+  end
+
+  defp flow_inventory(workflow) do
+    workflow
+    |> Workflow.flow_graph()
+    |> Multigraph.edges()
+    |> Enum.map(fn edge ->
+      {node_identity(workflow, edge.v1), node_identity(workflow, edge.v2), edge.label}
+    end)
+    |> Enum.sort()
+  end
+
+  defp node_identity(_workflow, %Root{}), do: :root
+  defp node_identity(_workflow, %Join{joins: joins}), do: {:join, joins}
+
+  defp node_identity(_workflow, %InputBinding{} = binding) do
+    {:input_binding, binding.target_component_hash, binding.source_order, binding.bindings}
+  end
+
+  defp node_identity(workflow, node) do
+    owner =
+      workflow.graph
+      |> Multigraph.in_edges(node, by: :component_of)
+      |> Enum.find(fn edge -> edge.v1 != node end)
+
+    case owner do
+      %{v1: %{name: owner_name}, properties: %{kind: kind}} ->
+        {:owned, owner_name, kind}
+
+      _ ->
+        intrinsic_node_identity(node)
+    end
+  end
+
+  defp intrinsic_node_identity(%{__struct__: module, name: name}) when not is_nil(name),
+    do: {module, name}
+
+  defp intrinsic_node_identity(%{__struct__: module, hash: hash}), do: {module, hash}
+end

--- a/test/workflow/named_connection_test.exs
+++ b/test/workflow/named_connection_test.exs
@@ -230,6 +230,35 @@ defmodule Runic.Workflow.NamedConnectionTest do
       end
     end
 
+    test "replay preserves port contracts applied after component construction" do
+      producer =
+        Runic.step(fn input -> input + 1 end, name: :producer)
+        |> Map.put(:outputs, value: [type: :integer])
+
+      consumer =
+        Runic.step(fn input -> input * 2 end, name: :consumer)
+        |> Map.put(:inputs, value: [type: :integer])
+
+      original =
+        Workflow.new()
+        |> Workflow.add(producer)
+        |> Workflow.add(consumer,
+          connections: [[from: {:producer, :value}, to: :value]]
+        )
+
+      [producer_event, consumer_event] = Workflow.build_log(original)
+      assert producer_event.output_ports == [value: [type: :integer]]
+      assert consumer_event.input_ports == [value: [type: :integer]]
+
+      rebuilt = original |> Workflow.build_log() |> Workflow.from_log()
+
+      for workflow <- [original, rebuilt] do
+        assert workflow
+               |> Workflow.react_until_satisfied(5)
+               |> Workflow.raw_productions(:consumer) == [12]
+      end
+    end
+
     test "round-trips deterministic connection data and equivalent lowering" do
       original = positional_sum_workflow()
 


### PR DESCRIPTION
Codex:

## Stack

This is the third PR in the issue #11 implementation stack.

- #12 — grouped replay correctness, based on `main`
- #13 — durable named-port lowering and invocation contracts, based on #12
- **This PR** — composite-boundary and nested-workflow replay closure, based on #13

## What changed

- add a versioned `Runic.Workflow.Definition` for workflows deliberately used as nested components
- persist the child workflow's stable hash, boundary input/output ports, and ordered child build log inside the parent's `ComponentAdded` event
- stop flattening child construction events into the parent log for explicit workflow boundaries
- reconstruct the child independently before reconnecting its boundary during parent replay
- register an explicitly bounded child as an authored component while retaining its internal invokables in compiled flow
- compile `output_ports` with `from: component_name` into precise `:component_of` output ownership edges
- resolve downstream named connections from the selected child output port to its internal output node
- group multiple boundary ports backed by the same output node so child result queries do not duplicate one internal production
- retain output declarations without `:from` for contract-only use without guessing a compiled source
- leave internal compiler workflows without declared boundary ports on their existing composition path

## Durable boundary model

```elixir
child =
  Workflow.new(
    name: :child,
    input_ports: [in: [type: :integer]],
    output_ports: [out: [type: :integer, from: :inner]]
  )
  |> Workflow.add(inner)

parent =
  Workflow.new(name: :parent)
  |> Workflow.add(source)
  |> Workflow.add(child,
    connections: [[from: {:source, :out}, to: :in]]
  )
```

The parent log now contains one nested definition rather than a partial quoted `%Workflow{}` plus flattened child events:

```elixir
%ComponentAdded{
  name: :child,
  connections: [%Connection{target: :child, target_port: :in}],
  workflow_definition: %Workflow.Definition{
    version: 1,
    name: :child,
    input_ports: [in: [type: :integer]],
    output_ports: [out: [type: :integer, from: :inner]],
    build_log: [%ComponentAdded{name: :inner}]
  }
}
```

Runtime facts, run context, hooks, and runnable state are intentionally excluded from the construction definition.

## Boundary topology

```mermaid
flowchart LR
  S[Source component] -->|connects_to with port binding| C[Child workflow component]
  S1[Source invokable] -->|flow| B1[InputBinding]
  B1 -->|flow replaces child Root| I[Child internal entry]
  I --> O[Child internal output]
  C -. component_of output port .-> O
  O -->|flow| B2[Downstream InputBinding]
  B2 --> D[Downstream target]
```

The logical graph owns the source-to-child relationship. The compiled graph owns the binder and internal flow. The child's output ownership edge supports result attribution and downstream port resolution without making binders public outputs.

## Composite closure coverage

New original-versus-replayed tests cover:

- named input into a child workflow
- whole-value input into a child workflow
- named output from a child workflow into a downstream component
- multiple boundary ports backed by one internal output node
- `Accumulator` state production
- `StateMachine` state initialization and transition
- named input into `Map` followed by map-linked `Reduce` fan-in
- component and compiled-flow semantic inventories
- ETF round-trip of nested definitions
- unsupported nested-definition version rejection

## Deliberate boundaries

- only workflows declaring `input_ports`, `output_ports`, or both are treated as authored nested boundaries
- internal Map/Rule/compiler workflows without boundary ports retain existing composition and build-log behavior
- an output port needs `from: component_name` before it can be used as a downstream named source; unbound output contracts remain valid but are not inferred
- nested construction definitions do not persist runtime context, hooks, facts, or runnable state
- this PR does not add `runtime_graph/1` or serializer `view:` selection; those remain optional Priority 2 follow-up work

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- focused boundary, named-connection, and grouped-replay suites
- `mix test` — 55 doctests, 1370 tests, 0 failures, 13 skipped
- `mix docs` — generated successfully; only existing hidden-event reference warnings remain
- `git diff --check`

Runic has no `mix precommit` task or alias, so the available repository-equivalent gates above were run directly.
