### PR TITLE
Fix workflow identity collisions with canonical SHA-256 identities

### DIFF
--- a/.docs/identity-benchmark.exs
+++ b/.docs/identity-benchmark.exs
@@ -1,0 +1,23 @@
+alias Runic.Identity
+
+max_phash = 4_294_967_296
+
+composite_phash2 = fn term ->
+  high = :erlang.phash2(term, max_phash)
+  low = :erlang.phash2({:phash2_64_v1, :secondary, term}, max_phash)
+  high * max_phash + low
+end
+
+small = {%{answer: 42}, {:producer, :parent}}
+large = {%{payload: :binary.copy(<<42>>, 64 * 1024)}, {:producer, :parent}}
+
+Benchee.run(
+  %{
+    "phash2_64_v1" => composite_phash2,
+    "runic_canonical_v1 + sha256" => &Identity.digest(:fact_content, &1)
+  },
+  inputs: %{"small Fact basis" => small, "64 KiB Fact basis" => large},
+  time: 3,
+  memory_time: 1,
+  reduction_time: 1
+)

--- a/.docs/issue-16-phash2-collision-reproduction.exs
+++ b/.docs/issue-16-phash2-collision-reproduction.exs
@@ -1,0 +1,153 @@
+alias Runic.Workflow
+alias Runic.Workflow.{Fact, Step}
+
+require Runic
+
+run_parallel_steps = fn workflow, left_name, right_name ->
+  {workflow, runnables} = Workflow.prepare_for_dispatch(workflow)
+  left_runnable = Enum.find(runnables, &(&1.node.name == left_name))
+  right_runnable = Enum.find(runnables, &(&1.node.name == right_name))
+
+  executed_left = Workflow.execute_runnable(left_runnable)
+  executed_right = Workflow.execute_runnable(right_runnable)
+
+  applied =
+    workflow
+    |> Workflow.apply_runnable(executed_left)
+    |> Workflow.apply_runnable(executed_right)
+
+  %{
+    isolated: %{
+      left: executed_left.result,
+      right: executed_right.result
+    },
+    applied: applied,
+    results: Workflow.results(applied, [left_name, right_name], facts: true, all: true)
+  }
+end
+
+summarize = fn run, left_name, right_name ->
+  left_isolated = run.isolated.left
+  right_isolated = run.isolated.right
+  left_applied = run.results[left_name] |> List.first()
+  right_applied = run.results[right_name] |> List.first()
+
+  %{
+    isolated_hashes: {left_isolated.hash, right_isolated.hash},
+    isolated_values: {left_isolated.value, right_isolated.value},
+    applied_values: {left_applied.value, right_applied.value},
+    collision?: left_isolated.hash == right_isolated.hash,
+    silently_aliased?:
+      left_isolated.value != right_isolated.value and
+        left_applied.value == right_applied.value
+  }
+end
+
+root_hash = Fact.new(value: %{}).hash
+
+# Issue #16's OTP-specific deterministic collision, using its explicit Step.new hashes.
+step_new_left =
+  Step.new(
+    name: "left",
+    hash: "probe-step-11396",
+    work: fn _input -> %{value: 11_396} end
+  )
+
+step_new_right =
+  Step.new(
+    name: "right",
+    hash: "probe-step-19508",
+    work: fn _input -> %{value: 19_508} end
+  )
+
+step_new_run =
+  Workflow.new("issue_16_step_new")
+  |> Workflow.add(step_new_left)
+  |> Workflow.add(step_new_right)
+  |> Workflow.plan_eagerly(%{})
+  |> run_parallel_steps.("left", "right")
+
+# Macro construction changes the producer hashes, so the issue's exact values do not
+# collide under this ancestry. Runtime context lets us vary results without changing
+# the macro-built Step identities, making a second deterministic collision search fair.
+macro_left =
+  Runic.step(fn _input -> %{value: context(:value)} end,
+    name: :left
+  )
+
+macro_right =
+  Runic.step(fn _input -> %{value: context(:value)} end,
+    name: :right
+  )
+
+macro_reported_pair_run =
+  Workflow.new("issue_16_macro_reported_pair")
+  |> Workflow.add(macro_left)
+  |> Workflow.add(macro_right)
+  |> Workflow.put_run_context(%{
+    left: %{value: 11_396},
+    right: %{value: 19_508}
+  })
+  |> Workflow.plan_eagerly(%{})
+  |> run_parallel_steps.(:left, :right)
+
+search_limit = 250_000
+max_phash = 4_294_967_296
+
+left_hashes =
+  Enum.reduce(0..search_limit, %{}, fn value, hashes ->
+    basis = {%{value: value}, {macro_left.hash, root_hash}}
+    hash = :erlang.phash2(basis, max_phash)
+
+    Map.put_new(hashes, hash, value)
+  end)
+
+macro_collision =
+  Enum.find_value(0..search_limit, fn right_value ->
+    basis = {%{value: right_value}, {macro_right.hash, root_hash}}
+    hash = :erlang.phash2(basis, max_phash)
+
+    case Map.fetch(left_hashes, hash) do
+      {:ok, left_value} when left_value != right_value ->
+        %{hash: hash, left_value: left_value, right_value: right_value}
+
+      _other ->
+        nil
+    end
+  end)
+
+macro_collision_run =
+  case macro_collision do
+    nil ->
+      nil
+
+    %{left_value: left_value, right_value: right_value} ->
+      Workflow.new("issue_16_macro_collision")
+      |> Workflow.add(macro_left)
+      |> Workflow.add(macro_right)
+      |> Workflow.put_run_context(%{
+        left: %{value: left_value},
+        right: %{value: right_value}
+      })
+      |> Workflow.plan_eagerly(%{})
+      |> run_parallel_steps.(:left, :right)
+  end
+
+%{
+  environment: %{
+    elixir: System.version(),
+    otp_release: :erlang.system_info(:otp_release) |> List.to_string()
+  },
+  step_new: summarize.(step_new_run, "left", "right"),
+  macro_reported_pair: %{
+    step_hashes: {macro_left.hash, macro_right.hash},
+    outcome: summarize.(macro_reported_pair_run, :left, :right)
+  },
+  macro_collision_search: %{
+    scheme: :phash2_32_primary,
+    range: 0..search_limit,
+    collision: macro_collision,
+    outcome:
+      if(macro_collision_run, do: summarize.(macro_collision_run, :left, :right), else: nil)
+  }
+}

--- a/.docs/phash2-composite-identity-implementation-plan.md
+++ b/.docs/phash2-composite-identity-implementation-plan.md
@@ -5,7 +5,7 @@
 - **Target baseline:** Runic `0.1.0-alpha.9`
 - **Trigger:** [GitHub issue #16](https://github.com/zblanco/runic/issues/16), "Workflow graph silently aliases distinct facts on 32-bit phash2 collisions"
 - **Reproduction:** [Issue 16 collision script](issue-16-phash2-collision-reproduction.exs)
-- **Long-term successor:** SHA-256 content and occurrence identities in the second stacked PR
+- **Long-term successor:** [SHA-256 Content and Occurrence Identity Implementation Plan](sha256-content-identity-implementation-plan.md)
 - **Related distributed-runtime planning:** `zw/dist-runtime:.docs/distributed-durable-runtime-core-plan.md`, section 6
 
 ## Executive decision

--- a/.docs/phash2-composite-identity-implementation-plan.md
+++ b/.docs/phash2-composite-identity-implementation-plan.md
@@ -1,0 +1,478 @@
+# Composite `phash2` Identity Stopgap Implementation Plan
+
+- **Status:** Implemented on `zw/issue-16-phash2-composite` for draft review
+- **Date:** 2026-08-29
+- **Target baseline:** Runic `0.1.0-alpha.9`
+- **Trigger:** [GitHub issue #16](https://github.com/zblanco/runic/issues/16), "Workflow graph silently aliases distinct facts on 32-bit phash2 collisions"
+- **Reproduction:** [Issue 16 collision script](issue-16-phash2-collision-reproduction.exs)
+- **Long-term successor:** SHA-256 content and occurrence identities in the second stacked PR
+- **Related distributed-runtime planning:** `zw/dist-runtime:.docs/distributed-durable-runtime-core-plan.md`, section 6
+
+## Executive decision
+
+Ship a deliberately temporary `phash2_64_v1` identity scheme that combines two domain-separated 32-bit `:erlang.phash2/2` results into one non-negative integer. Apply it through the existing `Runic.Workflow.Components.fact_hash/1` funnel, use it for Runnable IDs, and add a fail-fast fact identity conflict check before Multigraph insertion.
+
+This plan reduces the probability of an accidental collision by many orders of magnitude without first introducing canonical encoding, cryptographic digests, new graph identity structs, or distributed occurrence semantics. It does not claim cryptographic collision resistance and must not become the durable identity contract for `Runic.Runtime`.
+
+The rollout is an alpha hard cut:
+
+- generated hashes change for components, closures, facts, joins, connections, and compiler-generated nodes;
+- active persisted workflows, snapshots, fact-store keys, and event histories must not silently mix the old 32-bit and new composite schemes;
+- applications either rebuild/reset alpha-era persisted state or run an explicit application-owned migration;
+- the core library does not retain permanent dual-hash behavior.
+
+## 1. Goals and non-goals
+
+### 1.1 Goals
+
+1. Prevent the known issue #16 values from sharing the same generated Fact identity.
+2. Reduce accidental hash collision probability from a 32-bit to an approximately 64-bit space.
+3. Preserve the current public shape of generated hashes as non-negative Elixir integers.
+4. Change the shared hash implementation rather than editing every macro and component constructor individually.
+5. Replace silent fact aliasing with an explicit `Runic.Workflow.IdentityConflictError` if a collision still reaches graph insertion.
+6. Upgrade the separate 27-bit default Runnable ID calculation to the same composite scheme.
+7. Preserve deterministic hashing across supported machine architectures and ERTS versions, subject to `phash2`'s existing guarantees.
+8. Add regression, replay, rehydration, and store tests that prove the new behavior.
+
+### 1.2 Non-goals
+
+- Cryptographic or adversarial collision resistance.
+- Canonical cross-language or cross-OTP-major content encoding.
+- Stable public identities for a distributed Journal protocol.
+- Separating component definition, graph node occurrence, fact occurrence, payload, activation, attempt, command, transaction, and event identities.
+- Resolving whether repeated equal root input is memoized or represents a new occurrence.
+- Repairing already-corrupted snapshots or event histories.
+- Making a consistent-hash placement ring authoritative for workflow ownership.
+- Retaining `phash2_64_v1` as a permanent compatibility layer after SHA-256 migration.
+
+## 2. Current baseline and measured blast radius
+
+### 2.1 Hash production
+
+`Runic.Workflow.Components.fact_hash/1` currently returns one 32-bit value:
+
+```elixir
+@max_phash 4_294_967_296
+
+def fact_hash(value), do: :erlang.phash2(value, @max_phash)
+```
+
+The current checkout contains 136 `fact_hash` call sites across 11 files, but they funnel through this one function. They cover:
+
+- `Runic.step`, rule, condition, map, reduce, accumulator, FSM, aggregate, saga, and process-manager macros;
+- `Runic.Closure` source and captured-binding identity;
+- `Fact.new/1` over `{value, ancestry}`;
+- joins, conjunctions, connections, named-port `InputBinding`s, and compilation utilities;
+- workflow and pipeline component hashes;
+- some state initialization and invocation paths.
+
+The stopgap therefore changes generated identities broadly while requiring few production edits.
+
+### 2.2 Hash consumers
+
+Generated hashes are used as:
+
+- Multigraph vertex IDs through `Components.vertex_id_of/1`;
+- entries in `Workflow.components`, hook maps, `inputs`, and `mapped` indexes;
+- ancestry references `{producer_hash, parent_fact_hash}`;
+- fields in construction, runtime, lifecycle, map/reduce, join, and state events;
+- ETS and Mnesia fact-store keys;
+- `FactRef` hydration keys;
+- Runnable idempotency keys;
+- serializer and graph visualization identifiers.
+
+Most event fields and Store callbacks already use `term()`. Several component and lifecycle type specifications still say `integer()` or `non_neg_integer()`. A composite integer remains compatible with those shapes, although inconsistent specifications should be corrected while touching the relevant modules.
+
+### 2.3 Separate direct `phash2` sites
+
+There are nine direct `:erlang.phash2` uses across six source/test files. The correctness-relevant production uses are:
+
+- `Runic.Workflow.Runnable.new/3`;
+- `Runic.Workflow.Runnable.runnable_id/2`.
+
+Serializer and edgelist uses are display adapters. They are not workflow authority, but their collision behavior should be covered by the long-term plan.
+
+### 2.4 Silent insertion behavior
+
+`Workflow.apply_event/2` constructs the Fact recorded in `FactProduced` and calls `Workflow.log_fact/2`. `Private.log_fact/2` delegates directly to `Multigraph.add_vertex/2`. Multigraph checks only the configured vertex ID and returns the graph unchanged when that ID exists. It does not compare the existing and incoming vertices.
+
+The result is a successful event application that connects a new producer to an older, unrelated Fact.
+
+### 2.5 Reproduction evidence
+
+The Tidewave reproduction establishes both forms:
+
+| Construction | Isolated values | Shared 32-bit hash | Applied values |
+|---|---:|---:|---:|
+| Explicit `Step.new` issue pair | `11_396`, `19_508` | `2_532_671_132` | `11_396`, `11_396` |
+| Macro-built `Runic.step` searched pair | `135_162`, `17_404` | `2_237_561_755` | `135_162`, `135_162` |
+
+For the issue pair, the proposed secondary hash produces `1_691_296_184` and `2_524_127_245`, so the composite identities differ.
+
+## 3. Proposed `phash2_64_v1` scheme
+
+### 3.1 Calculation
+
+Add an explicit scheme name and combine the existing primary value with a domain-separated secondary pass:
+
+```elixir
+defmodule Runic.Workflow.Components do
+  @max_phash 4_294_967_296
+  @hash_scheme :phash2_64_v1
+
+  @spec hash_scheme() :: :phash2_64_v1
+  def hash_scheme, do: @hash_scheme
+
+  @spec fact_hash(term()) :: non_neg_integer()
+  def fact_hash(term) do
+    high = :erlang.phash2(term, @max_phash)
+    low = :erlang.phash2({@hash_scheme, :secondary, term}, @max_phash)
+
+    high * @max_phash + low
+  end
+end
+```
+
+Properties:
+
+- the return range is `0..2^64-1`;
+- the return value remains an Elixir integer;
+- the high 32 bits preserve the previous primary `phash2` output for diagnostics;
+- the scheme/version atom domain-separates the second pass and provides an obvious replacement point;
+- the calculation is deterministic wherever `phash2` is deterministic;
+- Elixir transparently represents values above the BEAM small-integer range as boxed integers.
+
+Do not call this `hash64/1` without the scheme name. The algorithm is specifically a composite of two non-cryptographic 32-bit hashes, not a general 64-bit content digest.
+
+### 3.2 Collision probability
+
+If the two domain-separated outputs behave independently for non-adversarial inputs, the birthday approximation is:
+
+```text
+p(collision) ≈ n(n - 1) / (2 × 2^64)
+```
+
+Examples:
+
+| Generated identities | Approximate accidental-collision probability |
+|---:|---:|
+| 1,001 | 1 in 36.8 trillion |
+| 100,000 | 1 in 3.69 billion |
+| 1,000,000 | 1 in 36.9 million |
+
+These numbers are engineering estimates, not a security claim. An attacker can deliberately search `phash2` outputs, and the two passes have no cryptographic independence proof.
+
+### 3.3 Performance evidence
+
+Tidewave/Benchee on Elixir 1.19.5, OTP 28.5, and an AMD Ryzen 7 5800X measured compiled functions:
+
+| Method | Small Fact-shaped term | 64 KiB Fact-shaped term |
+|---|---:|---:|
+| One 32-bit `phash2` | 88.6 ns | 23.2 µs |
+| Composite two-pass `phash2` | 197 ns | 50.7 µs |
+| Deterministic ETF plus SHA-256 | 576 ns | 36.0 µs |
+
+The stopgap adds about 108 ns for the small identity terms most common in graph construction. It is not always faster for large values because it traverses the term twice. This is another reason not to treat the composite as the long-term payload digest.
+
+## 4. Fail-fast Fact conflict detection
+
+### 4.1 Required failure mode
+
+The composite reduces probability; it does not make collision impossible. A conflicting Fact at an existing identity must fail the apply operation rather than silently return the older vertex.
+
+Add a dedicated exception:
+
+```elixir
+defmodule Runic.Workflow.IdentityConflictError do
+  defexception [:identity, :existing, :incoming, :context]
+
+  @impl Exception
+  def message(error) do
+    "workflow identity conflict at #{inspect(error.identity)} " <>
+      "while #{error.context || "inserting a vertex"}"
+  end
+end
+```
+
+The exception should retain bounded diagnostic evidence. Avoid unconditionally rendering arbitrary Fact values into the message because they may be large or sensitive.
+
+### 4.2 Fact equivalence rules
+
+The current Fact hash basis is `{value, ancestry}`. `meta` is excluded. Conflict checking must use the same basis:
+
+```elixir
+defp equivalent_identity?(
+       %Fact{value: left, ancestry: ancestry},
+       %Fact{value: right, ancestry: ancestry}
+     ),
+     do: left === right
+
+defp equivalent_identity?(
+       %FactRef{ancestry: ancestry},
+       %FactRef{ancestry: ancestry}
+     ),
+     do: true
+
+defp equivalent_identity?(_existing, _incoming), do: false
+```
+
+`Fact`/`FactRef` equality is necessarily partial because a reference has no value. Mixed full/reference insertion therefore fails closed: matching ancestry alone is not identity proof. Lean replay inserts only references, while the existing rehydration implementation deliberately replaces graph vertices without calling `log_fact/2`.
+
+### 4.3 Guarded insertion
+
+Centralize Fact insertion in `Private.log_fact/2`:
+
+```elixir
+def log_fact(%Workflow{graph: graph} = workflow, fact)
+    when is_struct(fact, Fact) or is_struct(fact, FactRef) do
+  identity = Components.vertex_id_of(fact)
+
+  case Map.fetch(graph.vertices, identity) do
+    :error ->
+      %{workflow | graph: Multigraph.add_vertex(graph, fact)}
+
+    {:ok, existing} ->
+      if equivalent_identity?(existing, fact) do
+        workflow
+      else
+        raise IdentityConflictError,
+          identity: identity,
+          existing: identity_summary(existing),
+          incoming: identity_summary(fact),
+          context: "applying a produced fact"
+      end
+  end
+end
+```
+
+This directly protects the issue #16 path, lean replay, state/join/fan-in results that call `log_fact/2`, and any caller using `Workflow.log_fact/2`.
+
+### 4.4 Component collision boundary
+
+The stopgap does not attempt to define a canonical semantic comparison for every component struct. Macro-built components contain both reconstructable Closure data and compiled function values; raw `Step.new` components may contain only a function and explicit hash. A generic struct comparison would either reject legitimate idempotent additions or accept a second collision-prone hash as proof.
+
+Required limited controls are:
+
+- a Fact colliding with any non-Fact vertex raises when the Fact is logged;
+- composite hashes reduce same-type component collision probability;
+- the SHA-256 plan introduces domain-tagged component identities and canonical identity documents;
+- a later Multigraph adapter/wrapper may generalize conflict checking once each vertex family exposes reliable identity evidence.
+
+This limitation must be called out in release notes. The stopgap closes the demonstrated runtime corruption path but is not the complete identity architecture.
+
+## 5. Runnable identity
+
+`Runnable.new/3` currently calls one-argument `phash2`, whose default range is only `0..2^27-1`. Replace both constructors/helpers with the shared scheme and a Runnable domain tag:
+
+```elixir
+def new(node, fact, context) do
+  %__MODULE__{
+    id: runnable_id(node, fact),
+    node: node,
+    input_fact: fact,
+    context: context,
+    status: :pending
+  }
+end
+
+def runnable_id(node, fact) do
+  Components.fact_hash({:runnable, node.hash, fact.hash})
+end
+```
+
+This remains a content-derived local Runnable key. It is not the distributed activation or attempt ID described in the SHA-256 plan.
+
+## 6. Compatibility and persistence policy
+
+### 6.1 Why this is a format break
+
+Changing the central function changes all newly generated identities, including:
+
+- Closure, component, work, condition, and reaction hashes;
+- connection and `InputBinding` IDs;
+- root, produced, state, reduced, joined, and fan-out Fact hashes;
+- ancestry references and graph indexes;
+- Runnable IDs;
+- fact-store keys and persisted event fields.
+
+Construction replay usually restores the recorded `ComponentAdded.hash`, which can make old histories appear to work. That is not sufficient proof of compatibility: old events without explicit hashes, new work appended to an old stream, rebuilt compiler artifacts, and fact-store references can create a mixed identity graph.
+
+### 6.2 Chosen alpha policy
+
+For the core library:
+
+1. Document `phash2_32_v0` histories as incompatible with `phash2_64_v1` continuation.
+2. Bump the next alpha release and note that persisted workflows/snapshots must be rebuilt.
+3. Do not auto-detect a scheme from integer width; small composite outputs can still fit in 32 bits.
+4. Do not silently recompute hashes during replay when an event contains an explicit historical hash.
+5. Do not add a permanent `{old_hash, new_hash}` index.
+6. Allow consuming applications to write one-off migrations if their retained source events and Fact values are sufficient.
+
+If a consumer cannot reset alpha data, it should stay on the old Runic version until the SHA-256 migration/upcaster is available rather than create a mixed stream.
+
+## 7. Implementation phases
+
+### Phase P0 — Freeze evidence and baseline
+
+Deliver:
+
+- move the issue reproduction into an ExUnit regression fixture while retaining the Tidewave script;
+- capture the current benchmark as a reproducible Benchee script or test-support module;
+- assert the current issue pair collides under the primary 32-bit pass;
+- enumerate persisted consumers that require reset or migration instructions.
+
+Gate: the regression fails for the current silent-alias behavior and records isolated versus applied results.
+
+### Phase P1 — Composite hash helper
+
+Deliver:
+
+- add `Components.hash_scheme/0`;
+- replace `Components.fact_hash/1` with `phash2_64_v1`;
+- document range and non-cryptographic status;
+- update narrow types/docs that incorrectly claim string-only or 32-bit identities;
+- add deterministic test vectors for atoms, AST, maps, binary payloads, closures, and Fact bases.
+
+Gate: every content-addressability test preserves equality/inequality semantics without relying on old numeric values.
+
+### Phase P2 — Fact identity conflict guard
+
+Deliver:
+
+- add `Runic.Workflow.IdentityConflictError`;
+- guard `Fact` and `FactRef` insertion in `Private.log_fact/2`;
+- keep exact duplicate Facts and FactRefs idempotent;
+- reject mixed Fact/FactRef insertion because a reference cannot prove value equality;
+- reject Fact-versus-Fact value/ancestry conflict and Fact-versus-component conflict;
+- bound error diagnostics and telemetry metadata.
+
+Gate: forcing two distinct Facts to the same explicit hash fails loudly and cannot produce a successful wrong result.
+
+### Phase P3 — Runnable and direct-call audit
+
+Deliver:
+
+- route `Runnable.new/3` and `Runnable.runnable_id/2` through the composite helper;
+- classify remaining direct `phash2` uses as correctness or display-only;
+- ensure visualization adapters never influence graph lookup or replay;
+- update doctests and type specifications.
+
+Gate: no correctness or idempotency identity in `lib/` uses default-range `phash2` directly.
+
+### Phase P4 — Persistence and release gate
+
+Deliver:
+
+- ETS and Mnesia fact save/load tests with composite keys;
+- full, lean, hybrid, and snapshot-tail replay coverage;
+- release notes declaring the alpha identity-format break;
+- consumer reset/migration checklist;
+- benchmark comparison in CI or a documented manual performance gate.
+
+Gate: no test mixes old/new schemes accidentally, and each supported Store round-trips composite keys.
+
+## 8. Expected file-level change surface
+
+### 8.1 Required production edits
+
+| File | Expected change |
+|---|---|
+| `lib/workflow/components.ex` | Composite implementation, scheme identifier, specifications, documentation |
+| `lib/workflow/runnable.ex` | Replace two direct default-range `phash2` uses |
+| `lib/workflow/private.ex` | Guard Fact/FactRef insertion |
+| `lib/workflow/identity_conflict_error.ex` | New explicit exception |
+| Selected component/event modules | Correct inconsistent hash type documentation/specifications |
+
+The 136 central-helper call sites should not require mechanical edits in this plan.
+
+### 8.2 Required tests
+
+| Test area | Coverage |
+|---|---|
+| New issue #16 regression | Explicit `Step.new` and macro-built `Runic.step` variants |
+| `test/content_addressability_test.exs` | Same basis remains equal; different basis remains different |
+| Fact/FactRef tests | Exact duplicate, placeholder equivalence, forced conflict |
+| Event-sourced tests | Live projection and replay equivalence with composite IDs |
+| Runner Store tests | ETS/Mnesia fact keys and stripped-value hydration |
+| Runnable tests | Stable 64-bit composite local ID |
+| Serializer tests | Composite integer rendering remains valid |
+
+### 8.3 Estimated review size
+
+- Approximately 4-8 production files with substantive edits.
+- Approximately 5-8 test files, depending on whether store/replay cases are consolidated.
+- No new runtime dependency.
+- No mass rewrite of `Runic.step` macro call sites.
+- One intentional persisted-format break.
+
+## 9. Test matrix
+
+### 9.1 Determinism
+
+- same term hashes identically across processes;
+- same macro source and captured bindings hash identically;
+- map insertion/enumeration differences produce the same `phash2` result for equal terms;
+- test vector values are stable on the supported OTP matrix.
+
+### 9.2 Collision regression
+
+- issue `Step.new` pair has different composite Fact hashes;
+- searched macro-built pair has different composite Fact hashes;
+- both applied workflow results remain correct;
+- applying two explicitly forced conflicting Facts raises `IdentityConflictError`;
+- error happens before drawing the second producer edge.
+
+### 9.3 Replay and storage
+
+- `FactProduced` event round-trip preserves the composite integer exactly;
+- `Workflow.from_events/1,2` reconstructs the same graph;
+- lean replay produces a `FactRef` with the same identity and ancestry;
+- ETS/Mnesia save and load use the composite key unchanged;
+- snapshot plus tail replay preserves mapped/join/fan-in indexes.
+
+### 9.4 Performance
+
+- benchmark small and 64 KiB Fact bases;
+- record allocations and boxed-integer impact;
+- investigate if small-term composite hashing exceeds 3× the current `phash2` time;
+- do not block on large-payload performance that the SHA/payload split intentionally replaces unless a current workload regresses materially.
+
+## 10. Acceptance criteria
+
+1. The issue #16 `Step.new` reproduction returns distinct correct results after application.
+2. A macro-built `Runic.step` collision probe returns distinct correct results after application.
+3. A deliberately forced identity conflict raises a typed error instead of aliasing.
+4. Exact duplicate Fact insertion remains idempotent.
+5. FactRef-based lean replay continues to resolve values from Store.
+6. Runnable IDs no longer use default-range 27-bit `phash2`.
+7. All content-addressability, event replay, checkpointing, Runner, and Store tests pass.
+8. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test`, and `git diff --check` pass.
+9. Release notes explicitly describe the persisted identity-format break.
+10. Documentation labels this scheme temporary and links to the SHA-256 successor plan.
+
+## 11. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| False sense of cryptographic safety | Name the scheme `phash2_64_v1`; document non-adversarial scope |
+| Two passes double traversal cost | Measured small-term overhead is about 108 ns; retain benchmark |
+| Large-term hashing is slower than SHA-256 | Do not position composite as payload digest; execute SHA plan |
+| Boxed 64-bit integers allocate | Benchmark allocations; accept as temporary or use a later identity struct |
+| Old/new histories mix | Alpha hard cut and explicit consumer reset/migration policy |
+| Collision still happens | Fail-fast Fact conflict guard |
+| Component same-type collision remains hard to compare | 64-bit reduction now; canonical component identity document in SHA plan |
+| Stopgap becomes permanent | Track removal as an explicit SHA migration gate |
+
+## 12. Removal condition
+
+`phash2_64_v1` can be removed when all of the following are true:
+
+- `Runic.Identity` and canonical SHA-256 encoding are implemented;
+- component definitions and graph node occurrences have distinct identities;
+- Fact occurrence and payload/content digests are separate;
+- graph insertion validates domain and identity evidence;
+- persisted events and snapshots declare/upcast their identity scheme;
+- Runner/Runtime idempotency uses activation, attempt, command, transaction, and event IDs rather than graph-local hashes;
+- known consumers have migrated or intentionally reset alpha-era data.
+
+At that point `phash2` may remain only inside BEAM Maps/ETS or explicitly private display/cache accelerators where exact-key comparison protects correctness.

--- a/.docs/runic-identity-v1-test-vectors.md
+++ b/.docs/runic-identity-v1-test-vectors.md
@@ -1,0 +1,49 @@
+# Runic Identity Scheme Version 1 Test Vectors
+
+- **Status:** Executable contract in `test/identity_test.exs`
+- **Scheme:** SHA-256
+- **Canonical codec:** `runic_canonical_v1`
+- **Preimage frame:** `runic-id`, zero separator, unsigned 16-bit version, unsigned 16-bit domain length, domain bytes, unsigned 64-bit payload length, canonical bytes
+
+All integers are unsigned big-endian lengths unless a canonical value rule says otherwise. Hex values are lowercase only for presentation.
+
+## Canonical primitive vectors
+
+| Logical value | Canonical bytes (hex) |
+|---|---|
+| `nil` | `00` |
+| `false` | `01` |
+| `true` | `02` |
+| `42` | `1000000000000000023432` |
+| `-7` | `1000000000000000022d37` |
+| `1.5` | `113ff8000000000000` |
+| binary `"hi"` | `2000000000000000026869` |
+| atom `:hi` | `2100000000000000026869` |
+
+Lists use tag `0x30`; tuples use tag `0x31`. Both contain an unsigned 64-bit item count followed by individually length-framed canonical values. Maps use tag `0x33`, sort entries by the complete canonical key bytes, and wrap each key/value pair with tag `0x32`.
+
+## Payload identity vector
+
+Identity document:
+
+```elixir
+%{
+  codec: :runic_canonical,
+  schema_version: 1,
+  value: %{a: 1, b: 2}
+}
+```
+
+Tagged text identity:
+
+```text
+runic:sha256:v1:payload:21205882d75b9c3a549850de3b90d8347acfd5b648858d1256ad64883511b90c
+```
+
+Compact binary identity (hex):
+
+```text
+01000100077061796c6f616421205882d75b9c3a549850de3b90d8347acfd5b648858d1256ad64883511b90c
+```
+
+Implementations must compare the scheme, version, domain, and all 32 digest bytes. Short display strings are never authoritative keys.

--- a/.docs/runic-identity-v1-test-vectors.md
+++ b/.docs/runic-identity-v1-test-vectors.md
@@ -22,6 +22,17 @@ All integers are unsigned big-endian lengths unless a canonical value rule says 
 
 Lists use tag `0x30`; tuples use tag `0x31`. Both contain an unsigned 64-bit item count followed by individually length-framed canonical values. Maps use tag `0x33`, sort entries by the complete canonical key bytes, and wrap each key/value pair with tag `0x32`.
 
+Projected structs use tag `0x41`, followed by an unsigned 64-bit byte length
+and the canonical encoding of `{module, projection_document}`. The outer tag is
+mandatory: an ordinary tuple, including `{:projected, module, document}`, must
+never have the same encoding as a projected struct. Identity references use
+tag `0x40` with the same byte-length framing around their compact binary form.
+
+These tags are covered by `test/identity_regression_test.exs`. This correction
+changes identities containing projected structs from the earlier draft; rebuild
+artifacts and fixtures created from that unreleased draft rather than mixing
+the two encodings.
+
 ## Payload identity vector
 
 Identity document:

--- a/.docs/sha256-content-identity-implementation-plan.md
+++ b/.docs/sha256-content-identity-implementation-plan.md
@@ -1,0 +1,1016 @@
+# SHA-256 Content and Occurrence Identity Implementation Plan
+
+- **Status:** Core identity foundation implemented on `zw/issue-16-sha256-identities`; distributed-runtime phases remain planned
+- **Date:** 2026-08-29
+- **Target baseline:** Runic `0.1.0-alpha.9`, after the [composite phash2 stopgap](phash2-composite-identity-implementation-plan.md)
+- **Trigger:** [GitHub issue #16](https://github.com/zblanco/runic/issues/16) and distributed durable-runtime identity requirements
+- **Reproduction:** [Issue 16 collision script](issue-16-phash2-collision-reproduction.exs)
+- **Related distributed-runtime planning:** `zw/dist-runtime:.docs/distributed-durable-runtime-core-plan.md`, section 6; `zw/dist-runtime:.docs/runic-runtime-contract-upgrade-plan.md`, sections 4, 6, and 9
+
+## Executive decision
+
+Replace overloaded integer graph hashes with versioned, domain-separated SHA-256 identities derived from a Runic-owned canonical encoding. At the same time, separate immutable content digests from causal occurrence, execution, activation, attempt, command, transaction, and event identities.
+
+The graph must no longer infer semantic multiplicity from content hashing:
+
+- component definitions have content digests;
+- authored graph nodes have node occurrence IDs that reference component definitions;
+- payload values have payload digests;
+- Facts have causal occurrence IDs and may additionally expose content/provenance digests;
+- workflow artifacts are Merkle-style digests over canonical construction records;
+- durable execution IDs are recorded explicitly and do not reuse graph hashes;
+- every graph key is domain-tagged;
+- duplicate insertion verifies identity evidence and fails closed on conflict.
+
+SHA-256 is the default because it is available through OTP `:crypto`, has broad operational/FIPS compatibility, and avoids adding a hashing dependency. The scheme is versioned so a later algorithm or canonical encoding can coexist through an explicit migration rather than an implicit behavior change.
+
+This is an alpha contract replacement, not a permanent dual-ID compatibility layer. Existing persisted fixtures receive a bounded one-time upcast/rebuild path or are intentionally reset.
+
+### Implementation boundary in this stacked PR
+
+Implemented and executable in this branch:
+
+- typed, versioned, domain-separated `%Runic.Identity{}` values;
+- `runic_canonical_v1`, bounded errors, preimage framing, integrity verification, and frozen vectors;
+- SHA-256 component-definition, connection-definition, workflow-artifact, payload, Fact-content, Fact-occurrence, activation, and attempt identities;
+- separate Fact payload/content/occurrence fields and explicit causal output coordinates;
+- distinct fan-out Fact occurrences for equal payloads at different output indexes;
+- identity-bearing `FactProduced` and `FanOutFactEmitted` events with full/lean replay fields;
+- transitionary payload Store callbacks for ETS and Mnesia;
+- serializers that retain full identities and never collapse binary identities through `phash2`;
+- macro escaping and type/guard migration needed for typed identities across the current Runic constructors.
+
+Still proposal, intentionally outside this core stack layer:
+
+- changing every graph component vertex from definition identity to an authored node-occurrence wrapper;
+- the distributed `ExecutionId`, command, transaction, event-position, authority-epoch, Journal, and ExecutionBackend contracts owned by the `zw/dist-runtime` effort;
+- a retained-history upcaster for external consumers and the final removal of temporary alpha compatibility fields;
+- cross-language conformance runners beyond the frozen byte-level vectors in [Runic Identity Scheme Version 1 Test Vectors](runic-identity-v1-test-vectors.md).
+
+The distinction is deliberate: this PR supplies the core identity vocabulary and causal Fact behavior that `main` can validate now without claiming that unmerged Journal or clustered-runtime authority exists.
+
+## 1. Why a hash-algorithm swap is insufficient
+
+Replacing this:
+
+```elixir
+:erlang.phash2({value, ancestry}, 4_294_967_296)
+```
+
+with this:
+
+```elixir
+:crypto.hash(:sha256, :erlang.term_to_binary({value, ancestry}))
+```
+
+would reduce collision probability, but it would not complete the required design:
+
+1. `term_to_binary/2` with `:deterministic` guarantees identical bytes only within one OTP major release.
+2. Runtime function terms, PIDs, ports, references, and release-local metadata are not portable content definitions.
+3. Components, Facts, and compiler nodes currently share one untagged vertex ID space.
+4. Equal values at two fan-out indexes are distinct causal occurrences even if payload bytes are identical.
+5. Repeated equal root inputs may be either memoized content or separate ingress occurrences; the policy must be explicit.
+6. Runnable hashes currently conflate a logical activation with local idempotency.
+7. Distributed commands, Journal transactions, attempts, and events require different deduplication and recovery semantics.
+8. Content-addressed payload storage must not become the graph occurrence model.
+
+The implementation therefore introduces an identity system, not merely a stronger helper function.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. Make accidental or adversarial content-digest collision infeasible for practical Runic workloads.
+2. Define stable bytes independently of map iteration order, source line metadata, and OTP-major ETF encoding changes.
+3. Domain-separate every public identity family.
+4. Preserve causal multiplicity independently of payload deduplication.
+5. Produce portable component, workflow artifact, payload, Fact content, and event digests.
+6. Give local Workflow and future `Runic.Runtime` one identity vocabulary.
+7. Support deterministic replay, remote execution validation, immutable artifact caching, and content-addressed payload storage.
+8. Detect conflicting identity evidence instead of relying on hash strength alone.
+9. Provide explicit test vectors and codec versions for adapters and other languages.
+10. Remove `phash2` from correctness, integrity, idempotency, and public durable identity roles.
+
+### 2.2 Non-goals
+
+- Claiming exactly-once execution of arbitrary external effects.
+- Using a process registry, placement ring, or broker as workflow authority.
+- Persisting raw live `%Runnable{}` structs as a portable protocol.
+- Canonicalizing arbitrary BEAM terms without an allowlist and domain schema.
+- Hiding incompatible identity changes behind permanent dual reads/writes.
+- Requiring every local, ephemeral workflow to start a distributed Runtime.
+- Making SHA-256 output itself an occurrence ID when the semantic occurrence must remain distinct.
+- Signing/authenticating content. Integrity digest and authenticity are separate capabilities.
+
+## 3. Current code and change inventory
+
+### 3.1 Central hash sites
+
+The current checkout has:
+
+- 136 `fact_hash` call sites across 11 files;
+- nine direct `:erlang.phash2` sites across six files;
+- 29 integer-only guards/specifications across 15 files;
+- active `Multigraph.add_vertex` calls in `Runic`, `Workflow`, and `Workflow.Private`;
+- hash-bearing fields across construction, lifecycle, Fact, activation, state, join, fan-out/fan-in, and map/reduce event modules.
+
+The central helper makes an initial shadow implementation possible, but domain separation requires classifying most call sites rather than replacing the helper body once.
+
+### 3.2 Current overloaded meanings
+
+The word `hash` currently means several different things:
+
+| Current use | Actual semantic need |
+|---|---|
+| Closure hash | Component/executable definition digest |
+| Step/Condition/Rule hash | Definition digest, authored node identity, or both |
+| Workflow hash | Artifact/revision content digest |
+| Fact hash | Payload + provenance content and graph occurrence |
+| FactRef hash | Reference to one Fact occurrence |
+| Connection/InputBinding hash | Authored connection or compiler-node identity |
+| Runnable ID | Local activation/idempotency occurrence |
+| Fact-store key | Payload lookup, currently coupled to Fact causal identity |
+| Event hash fields | References to nodes/Facts in one graph projection |
+| Serializer `phash2` | Display-safe DOM/graph identifier |
+
+The new model gives each meaning its own type/domain.
+
+### 3.3 Existing useful seams
+
+The migration should reuse:
+
+- normalized macro AST and captured bindings in `Runic.Closure`;
+- `Runic.Component.source/1` and built-in component protocols;
+- chronological construction/runtime events;
+- `FactRef` and separate Store value hydration;
+- prepare → execute → apply and typed events;
+- existing Workflow component registry and Multigraph vertex identifier callback;
+- Store/Executor/Scheduler seams during transition;
+- planned Journal/ExecutionBackend/PayloadStore/Runtime contracts for the distributed profile.
+
+## 4. Identity taxonomy
+
+### 4.1 Content identities
+
+| Identity | Domain | Basis | Property |
+|---|---|---|---|
+| Component definition digest | `:component_definition` | Canonical executable definition, bindings, ports, semantic options | Equal executable definitions compare equal |
+| Connection definition digest | `:connection_definition` | Canonical source/target node keys, ports, selectors, paths | Equal authored connection intent compares equal |
+| Workflow artifact digest | `:workflow_artifact` | Canonical nodes, connections, boundary ports, schema/version | Immutable reusable program identity |
+| Payload digest | `:payload` | Canonical logical value bytes | Equal values can deduplicate storage |
+| Fact content digest | `:fact_content` | Producer definition, parent content, output coordinate, payload digest | Causal content/memoization key |
+| Event data digest | `:event_data` | Canonical versioned event data | Integrity and deterministic event ID derivation input |
+| Snapshot/segment digest | `:snapshot` / `:segment` | Canonical encoded bytes and manifest | Restore integrity |
+
+### 4.2 Occurrence and protocol identities
+
+| Identity | Meaning | Generation |
+|---|---|---|
+| Namespace | Tenant/application isolation | Supplied and validated |
+| Node occurrence ID | One authored node position in an artifact/revision | Derived from artifact-local stable node key and component digest |
+| Execution ID | One evolving workflow instance | Preallocated globally unique opaque ID |
+| Input command ID | Semantic ingress idempotency | Caller-supplied/preallocated; stored with request digest |
+| Activation ID | One causal scheduling occurrence | Derived or allocated once, then recorded |
+| Attempt ID | One delivery/execution attempt | Derived from activation ID and attempt number |
+| Fact occurrence ID | One output coordinate of one activation | Derived from activation ID, output port, and output index |
+| Transaction ID | One conditional Journal mutation | Globally unique and queryable after ambiguity |
+| Event ID | One committed event occurrence | Derived from stream/transaction/position/batch offset or assigned by Journal |
+| Authority epoch | Fenced owner generation | Issued/enforced by authoritative Journal |
+| Journal position | Ordered stream/partition revision | Assigned atomically by Journal |
+
+Content digests may be equal across executions. Occurrence IDs must remain distinct where the model requires multiplicity.
+
+## 5. Core identity representation
+
+### 5.1 `Runic.Identity`
+
+Use an explicit struct in core code and events:
+
+```elixir
+defmodule Runic.Identity do
+  @enforce_keys [:scheme, :version, :domain, :digest]
+  defstruct scheme: :sha256, version: 1, domain: nil, digest: nil
+
+  @type domain ::
+          :component_definition
+          | :node_occurrence
+          | :connection_definition
+          | :workflow_artifact
+          | :payload
+          | :fact_content
+          | :fact_occurrence
+          | :activation
+          | :attempt
+          | :event_data
+          | :snapshot
+          | :segment
+
+  @type t :: %__MODULE__{
+          scheme: :sha256,
+          version: pos_integer(),
+          domain: domain(),
+          digest: <<_::256>>
+        }
+end
+```
+
+An identity is equal only when scheme, version, domain, and digest are equal. This prevents a payload digest from aliasing a component or Fact vertex even if the raw 32 bytes match.
+
+The struct is the Elixir API representation. A compact wire/storage encoding is:
+
+```text
+runic:<scheme>:v<version>:<domain>:<base32-or-hex-digest>
+```
+
+Human strings are for logs, URLs, SQL text columns, and graph serializers. Binary/event codecs should encode numeric scheme/version/domain tags plus the raw 32-byte digest.
+
+### 5.2 Public constructors
+
+```elixir
+defmodule Runic.Identity do
+  alias Runic.Identity.Canonical
+
+  def digest(domain, identity_document) do
+    canonical = Canonical.encode!(identity_document)
+    digest_bytes(domain, canonical)
+  end
+
+  def derive(domain, ordered_identities_and_scalars) do
+    digest(domain, {:derive, ordered_identities_and_scalars})
+  end
+
+  def digest_bytes(domain, canonical_bytes) when is_binary(canonical_bytes) do
+    preimage = Preimage.frame_v1(domain, canonical_bytes)
+
+    %__MODULE__{
+      scheme: :sha256,
+      version: 1,
+      domain: domain,
+      digest: :crypto.hash(:sha256, preimage)
+    }
+  end
+end
+```
+
+Do not expose an untagged `sha256(term)` helper. Every call must select a registered domain and pass a domain-specific identity document.
+
+### 5.3 Domain-separated preimage
+
+Use unambiguous length framing:
+
+```elixir
+defmodule Runic.Identity.Preimage do
+  @magic "runic-id"
+  @version 1
+
+  def frame_v1(domain, canonical_bytes) do
+    domain_bytes = Atom.to_string(domain)
+
+    <<
+      @magic::binary,
+      0,
+      @version::unsigned-16,
+      byte_size(domain_bytes)::unsigned-16,
+      domain_bytes::binary,
+      byte_size(canonical_bytes)::unsigned-64,
+      canonical_bytes::binary
+    >>
+  end
+end
+```
+
+Test vectors must freeze the exact byte layout. Never build a digest preimage by ambiguous string concatenation or inspect output.
+
+## 6. Canonical encoding v1
+
+### 6.1 Decision
+
+Implement a restricted Runic canonical term codec rather than treating ETF as the durable digest encoding. `term_to_binary(term, [:deterministic])` may remain a same-OTP-major event/snapshot optimization, but it is not `runic_canonical_v1`.
+
+Canonical v1 supports only identity-safe logical values:
+
+- `nil`, booleans, atoms, integers, finite IEEE-754 floats;
+- binaries and UTF-8 strings as binaries with no implicit normalization;
+- lists and tuples with explicit distinct tags;
+- maps sorted by canonical encoded key bytes;
+- registered struct/projector documents represented as tagged maps;
+- `%Runic.Identity{}` using its compact binary identity encoding.
+
+It rejects:
+
+- functions and anonymous compiled closures;
+- PIDs, ports, references, and process-local resources;
+- arbitrary structs without a registered projector;
+- cyclic/improper structures outside the declared domain schema;
+- values exceeding configured depth, item, or byte limits.
+
+### 6.2 Encoder shape
+
+```elixir
+defmodule Runic.Identity.Canonical do
+  @spec encode!(term()) :: binary()
+
+  def encode!(nil), do: <<0x00>>
+  def encode!(false), do: <<0x01>>
+  def encode!(true), do: <<0x02>>
+
+  def encode!(integer) when is_integer(integer) do
+    bytes = Integer.to_string(integer)
+    frame(0x10, bytes)
+  end
+
+  def encode!(binary) when is_binary(binary), do: frame(0x20, binary)
+
+  def encode!(atom) when is_atom(atom) do
+    frame(0x21, Atom.to_string(atom))
+  end
+
+  def encode!(list) when is_list(list) do
+    encoded = Enum.map(list, &encode!/1)
+    sequence(0x30, encoded)
+  end
+
+  def encode!(tuple) when is_tuple(tuple) do
+    encoded = tuple |> Tuple.to_list() |> Enum.map(&encode!/1)
+    sequence(0x31, encoded)
+  end
+
+  def encode!(map) when is_map(map) and not is_struct(map) do
+    entries =
+      map
+      |> Enum.map(fn {key, value} -> {encode!(key), encode!(value)} end)
+      |> Enum.sort_by(&elem(&1, 0))
+
+    encoded_entries = Enum.map(entries, fn {key, value} -> frame(0x32, key <> value) end)
+    sequence(0x33, encoded_entries)
+  end
+end
+```
+
+The production encoder needs exact signed integer, float, length, overflow, recursion, and error rules; the example communicates the required explicit tagging and ordering, not the final byte constants.
+
+### 6.3 Identity projectors
+
+Hash identity documents, not entire live structs. Add a protocol:
+
+```elixir
+defprotocol Runic.Identity.Projectable do
+  @spec identity_document(t()) :: term()
+  def identity_document(value)
+end
+```
+
+Built-in components implement it. Custom components must opt in for portable content identity. A local-only component may continue to run in a local Workflow, but cannot be exported as a portable artifact or submitted to a durable distributed profile.
+
+## 7. Component and node identities
+
+### 7.1 Component definition digest
+
+For a Step, include executable semantics and exclude occurrence/presentation/runtime data:
+
+```elixir
+defimpl Runic.Identity.Projectable, for: Runic.Workflow.Step do
+  def identity_document(step) do
+    %{
+      kind: :step,
+      version: 1,
+      executable: closure_document(step.closure),
+      call_contract: canonical_call_contract(step.call_contract),
+      inputs: canonical_ports(step.inputs),
+      outputs: canonical_ports(step.outputs),
+      meta_requirements: canonical_meta_refs(step.meta_refs)
+    }
+  end
+end
+```
+
+Exclude:
+
+- `name`, which belongs to the authored node occurrence;
+- the compiled `work` function;
+- source line/file metadata that does not change semantics;
+- mutable `run_context` values;
+- local hooks and scheduler policy functions;
+- diagnostics and Inspect representations.
+
+Closure identity includes normalized AST, explicit captured bindings, required module/function references, and a declared code/schema version. Closure metadata needed only to re-evaluate code must be split into semantic and diagnostic subsets.
+
+### 7.2 Authored node occurrence
+
+Two graph nodes may reference the same component definition and still be distinct positions:
+
+```elixir
+node_id =
+  Identity.derive(:node_occurrence, [
+    artifact_local_parent_key,
+    authored_name_or_stable_key,
+    sibling_ordinal,
+    component_definition_digest
+  ])
+```
+
+Do not derive node occurrence from component content alone. Explicit authored node keys are preferable to sibling ordinals because they survive unrelated graph edits.
+
+Proposed node wrapper:
+
+```elixir
+%Runic.Workflow.Node{
+  id: node_occurrence_id,
+  definition_digest: component_definition_digest,
+  name: :charge_card,
+  component: step
+}
+```
+
+The pure Workflow may introduce this wrapper internally before exposing it publicly. Multigraph keys use `node.id`, while `Runic.Component` continues to execute `node.component`.
+
+### 7.3 Workflow artifact digest
+
+Build a Merkle-style canonical artifact document:
+
+```elixir
+artifact_document = %{
+  kind: :workflow_artifact,
+  version: 1,
+  boundary: %{inputs: input_ports, outputs: output_ports},
+  nodes:
+    nodes
+    |> Enum.map(&node_record/1)
+    |> Enum.sort_by(&Identity.to_binary(&1.id)),
+  connections:
+    connections
+    |> Enum.map(&connection_record/1)
+    |> Enum.sort_by(&Identity.to_binary(&1.id))
+}
+
+artifact_digest = Identity.digest(:workflow_artifact, artifact_document)
+```
+
+Runtime context, active Facts, hooks that are not portable, scheduler state, process IDs, and execution history are excluded.
+
+## 8. Fact, payload, and causal occurrence identities
+
+### 8.1 Proposed Fact representation
+
+```elixir
+defmodule Runic.Workflow.Fact do
+  defstruct [
+    :id,
+    :content_digest,
+    :payload_digest,
+    :value,
+    :ancestry,
+    meta: %{}
+  ]
+end
+
+defmodule Runic.Workflow.FactAncestry do
+  @enforce_keys [:producer_node_id, :parent_fact_id]
+  defstruct [:producer_node_id, :parent_fact_id, :activation_id, :output_port, :output_index]
+end
+```
+
+`FactRef` retains `id`, `content_digest`, `payload_digest`, and ancestry but omits `value`.
+
+### 8.2 Payload digest
+
+```elixir
+payload_document = %{
+  codec: :runic_canonical,
+  schema_version: 1,
+  value: value
+}
+
+payload_digest = Identity.digest(:payload, payload_document)
+```
+
+Equal payloads may share immutable storage. The payload digest is never the graph vertex ID.
+
+### 8.3 Fact content digest
+
+```elixir
+content_digest =
+  Identity.derive(:fact_content, [
+    producer_component_definition_digest,
+    parent_fact_content_digest,
+    output_port,
+    output_index,
+    payload_digest
+  ])
+```
+
+This supports memoization and causal-content comparison. Whether `output_index` belongs in content depends on the operation semantics; the default includes it because collection position is semantically observable.
+
+### 8.4 Fact occurrence ID
+
+```elixir
+fact_id =
+  Identity.derive(:fact_occurrence, [
+    execution_id,
+    activation_id,
+    output_port,
+    output_index
+  ])
+```
+
+Retries of the same activation/output coordinate reproduce the same Fact occurrence ID. A separately scheduled activation produces a different ID even when content is identical.
+
+### 8.5 Root ingress policy
+
+Root Facts require an explicit mode:
+
+- `:distinct` — derive occurrence from the accepted input command ID; repeated equal values are distinct inputs;
+- `:memoized` — derive an application-declared semantic input key and reject conflicting payload content;
+- `:best_effort_local` — allocate a local occurrence ID without a durable command receipt.
+
+The distributed default is `:distinct`. Content digest remains available for deduplication in every mode.
+
+## 9. Graph identity and collision checks
+
+### 9.1 Type-tagged vertex keys
+
+Multigraph should receive explicit occurrence IDs:
+
+```elixir
+def vertex_id_of(%Runic.Workflow.Node{id: id}), do: id
+def vertex_id_of(%Runic.Workflow.Fact{id: id}), do: id
+def vertex_id_of(%Runic.Workflow.FactRef{id: id}), do: id
+def vertex_id_of(%Runic.Workflow.Root{id: id}), do: id
+```
+
+Because `Runic.Identity` includes `domain`, a Fact cannot alias a node or payload by raw digest equality.
+
+Bare integer/hash fallbacks should be removed from portable/durable construction. A compatibility decoder may translate old events during the bounded migration phase.
+
+### 9.2 Verified insertion
+
+Wrap every active `Multigraph.add_vertex` call in one core helper:
+
+```elixir
+def put_vertex(%Multigraph{} = graph, vertex) do
+  id = Components.vertex_id_of(vertex)
+
+  case Map.fetch(graph.vertices, id) do
+    :error ->
+      {:ok, Multigraph.add_vertex(graph, vertex)}
+
+    {:ok, existing} ->
+      if identity_evidence(existing) == identity_evidence(vertex) do
+        {:ok, graph}
+      else
+        {:error,
+         %IdentityConflict{
+           id: id,
+           existing: identity_summary(existing),
+           incoming: identity_summary(vertex)
+         }}
+      end
+  end
+end
+```
+
+Comparison uses domain-specific canonical identity evidence, not full live struct equality. Store the canonical document digest or enough immutable fields to reproduce it. Never treat a matching digest as the only proof when canonical bytes/documents are already available at an integrity boundary.
+
+## 10. Activation, attempt, Runnable, and event identities
+
+### 10.1 Runnable becomes an execution projection
+
+Replace content-hash `Runnable.id` with explicit occurrence references:
+
+```elixir
+%Runic.Workflow.Runnable{
+  activation_id: activation_id,
+  attempt_id: attempt_id,
+  attempt_number: 0,
+  node: node,
+  input_fact: fact,
+  context: context,
+  status: :pending
+}
+```
+
+The local pure API may allocate an ephemeral execution/activation namespace. Durable Runtime allocates and records identities before dispatch.
+
+### 10.2 Deterministic child identities
+
+```elixir
+activation_id =
+  Identity.derive(:activation, [
+    execution_id,
+    input_fact.id,
+    node.id,
+    activation_ordinal
+  ])
+
+attempt_id = Identity.derive(:attempt, [activation_id, attempt_number])
+```
+
+If an activation cannot be deterministically addressed from existing causal coordinates, allocate it once and persist it in the deciding event. Replay consumes the recorded ID; it never regenerates a different one.
+
+### 10.3 Durable events
+
+Version identity-bearing events rather than overloading legacy fields indefinitely:
+
+```elixir
+%Runic.Workflow.Events.FactProduced{
+  version: 2,
+  fact_id: fact.id,
+  content_digest: fact.content_digest,
+  payload: %Runic.Runtime.PayloadRef{digest: fact.payload_digest, ...},
+  ancestry: fact.ancestry,
+  producer_label: :produced,
+  weight: 1,
+  meta: %{}
+}
+```
+
+Future Runtime persistence wraps it:
+
+```elixir
+%Runic.Runtime.RecordedEvent{
+  schema_version: 1,
+  event_id: event_id,
+  stream_id: execution_id,
+  position: position,
+  transaction_id: transaction_id,
+  authority_epoch: epoch,
+  causation_id: activation_id,
+  correlation_id: input_command_id,
+  data_digest: Identity.digest(:event_data, canonical_event_data),
+  data: fact_produced
+}
+```
+
+Journal ordering and occurrence IDs remain authoritative. `committed_at` is diagnostic and excluded from deterministic identity.
+
+## 11. Store, Journal, and PayloadStore changes
+
+### 11.1 Transitional Runner Store
+
+Current Store callbacks use `save_fact(fact_hash, value, state)`. During transition:
+
+```elixir
+@callback save_payload(
+            payload_digest :: Runic.Identity.t(),
+            encoded_payload :: binary(),
+            state()
+          ) :: :ok | {:error, term()}
+
+@callback load_payload(Runic.Identity.t(), state()) ::
+            {:ok, binary()} | {:error, term()}
+```
+
+Fact occurrence and ancestry remain in events/graph projection. Payload storage is keyed only by payload digest.
+
+Do not permanently expand the legacy Store into the clustered correctness contract. This is a migration bridge to the planned `Runic.Runtime.PayloadStore` and `Runic.Runtime.Journal` behaviors.
+
+### 11.2 Runtime contract alignment
+
+- Journal owns ordered recorded events, expected position, command/transaction dedupe, authority epoch, and pending durable work.
+- PayloadStore owns immutable encoded payload bytes, digest verification, and durability receipts.
+- ExecutionBackend consumes committed dispatch requests identified by activation/attempt IDs.
+- Scheduler plans from occurrence-aware state; it does not invent durable identities after dispatch.
+- Runner remains a local implementation during migration, then moves behind Runtime as described by the dist-runtime plans.
+
+Content digest does not fence authority, order events, or prove exactly-once effects.
+
+## 12. Serializer and external representation changes
+
+Graph serializers must stop collapsing binary identities through `phash2`:
+
+```elixir
+def node_id(%{id: %Runic.Identity{} = id}) do
+  "n_" <> Runic.Identity.short_string(id, 20)
+end
+```
+
+The shortened string is display-only. Serializers should retain the full identity in element metadata so consumers can distinguish a theoretical prefix collision.
+
+Update:
+
+- Mermaid, DOT, Cytoscape, and edgelist IDs;
+- inspect output and error messages;
+- public results/query references;
+- JSON adapters and SQL column recommendations;
+- telemetry metadata with bounded string forms.
+
+Never feed a shortened/display identity back into Workflow lookup.
+
+## 13. Migration strategy
+
+### 13.1 Scheme identification
+
+Legacy values are explicitly `:phash2_32_v0` or `:phash2_64_v1`. New values are `%Runic.Identity{scheme: :sha256, version: 1, ...}`. Do not infer a scheme from integer size or binary length.
+
+### 13.2 One-time migration, not permanent dual identity
+
+For retained fixtures/consumers:
+
+1. Decode the old construction stream with its historical Runic version or a bounded upcaster.
+2. Reconstruct canonical component identity documents.
+3. Allocate stable node occurrence keys from names/connection positions and record any ambiguity.
+4. Recompute new construction events and workflow artifact digest.
+5. Replay runtime events in order, resolving old Fact values from inline events or the old fact store.
+6. Generate Fact content and occurrence identities using recorded causal coordinates and deterministic migration ordinals.
+7. Write a new stream/snapshot under a new execution/artifact revision.
+8. Verify result/state projections before switching readers.
+9. Retain the old stream read-only for audit/rollback until the migration horizon closes.
+
+Do not rewrite a stream in place.
+
+### 13.3 Irrecoverable ambiguity
+
+An old history may be impossible to migrate automatically when:
+
+- a silent collision already replaced one vertex and the second value was not retained in events/store;
+- an old component event has no reconstructable source/Closure and only a 32-bit hash;
+- two unnamed identical nodes cannot be assigned stable distinct occurrence positions;
+- required payload bytes are missing;
+- a local function/hook cannot be projected into a portable definition.
+
+Return an explicit migration diagnostic. Never guess and label the result verified.
+
+### 13.4 Consumer boundary
+
+Known consumers should migrate through fixtures on the contract branch. Local workspace/BYOC installations can use a coordinated stop/rebuild window. A clustered multi-tenant Runtime requires online version/capability checks, immutable artifact revisions, and fenced stream migration; those guarantees must not be inferred from a successful local reset.
+
+## 14. Implementation phases
+
+### Phase S0 — Identity ADR and executable test vectors
+
+Deliver:
+
+- final identity taxonomy and naming;
+- canonical encoding v1 specification;
+- domain registry and preimage frame specification;
+- fixed SHA-256 vectors for primitive terms, maps, AST, Closure, component, payload, Fact content, and derived occurrence IDs;
+- cross-OTP-major and cross-language vector harness;
+- benchmark baseline for encoding, digesting, equality, Map keys, ETS keys, and artifact construction.
+
+Gate: another implementation can reproduce every vector without running Runic code.
+
+### Phase S1 — Core `Runic.Identity` and canonical codec
+
+Deliver:
+
+- `Runic.Identity`, `Preimage`, `Canonical`, domain registry, encoding/string APIs;
+- structured codec errors and limits;
+- `Runic.Identity.Projectable` protocol;
+- collision/integrity error types;
+- property tests for map order, round trips where applicable, and domain separation;
+- optional streaming hash API for large payload encoders.
+
+Gate: identity bytes are stable across supported OTP majors and reject unsupported local terms.
+
+### Phase S2 — Component definitions and workflow artifacts
+
+Deliver:
+
+- identity projectors for every built-in component family;
+- Closure semantic identity document;
+- canonical ports, call contracts, connections, `InputBinding`, joins, conjunctions, and nested workflow definitions;
+- authored node occurrence model;
+- workflow artifact canonical document and Merkle digest;
+- custom-component portability diagnostics.
+
+Gate: equivalent graphs built in different processes produce the same artifact digest, while repeated identical components at distinct authored positions retain distinct node IDs.
+
+### Phase S3 — Fact occurrence and payload split
+
+Deliver:
+
+- new Fact/FactRef fields and ancestry struct;
+- payload digest and encoding;
+- Fact content digest and occurrence ID derivation;
+- explicit root ingress occurrence policy;
+- occurrence-aware map/reduce, join, accumulator, state, and repeated-equal-value behavior;
+- verified graph insertion wrapper for all vertex call sites.
+
+Gate: equal payloads at different fan-out indexes remain distinct graph occurrences while sharing one payload digest.
+
+### Phase S4 — Event, replay, Store, and serializer migration
+
+Deliver:
+
+- versioned identity-bearing event schemas and upcasters;
+- strict chronological projector support;
+- payload-oriented Store bridge and FactRef hydration;
+- snapshot manifest/version changes;
+- full identity graph serializers;
+- old fixture migration tool and diagnostics.
+
+Gate: live projection equals replay for every event prefix and snapshot tail under the new identity scheme.
+
+### Phase S5 — Activation and durable Runtime identities
+
+Deliver:
+
+- explicit execution, command, activation, attempt, transaction, event, epoch, and position types;
+- portable `RunnableDispatchRequested` and result commands;
+- Journal transaction/reference model integration;
+- ExecutionBackend and Scheduler use of recorded identities;
+- duplicate/stale/conflict tests;
+- invocation-scoped context and graph-revision binding.
+
+Gate: retries preserve Fact occurrence coordinates, duplicate results cannot apply twice, and stale authority cannot commit.
+
+### Phase S6 — Consumer migration and removal
+
+Deliver:
+
+- known SQLite/PostgreSQL consumer fixtures;
+- alpha history migration/reset runbooks;
+- removal of composite `fact_hash` correctness use;
+- removal of integer-only hash guards/specs;
+- removal of permanent legacy read/write paths after the bounded horizon;
+- updated public guides and telemetry.
+
+Gate: no correctness, integrity, idempotency, or durable public identity relies on `phash2`.
+
+## 15. Expected file-level change surface
+
+### 15.1 New core modules
+
+| Module | Responsibility |
+|---|---|
+| `Runic.Identity` | Typed scheme/domain/digest and public APIs |
+| `Runic.Identity.Preimage` | Versioned domain framing |
+| `Runic.Identity.Canonical` | Restricted deterministic encoder |
+| `Runic.Identity.Projectable` | Domain identity documents |
+| `Runic.Workflow.Node` | Authored node occurrence and component definition reference |
+| `Runic.Workflow.FactAncestry` | Explicit causal occurrence coordinates |
+| Identity/integrity conflict errors | Fail-closed diagnostics |
+
+Runtime phases additionally add the identity-bearing types already proposed by the distributed-runtime plans.
+
+### 15.2 Existing high-impact modules
+
+| Area | Expected edits |
+|---|---|
+| `lib/runic.ex` | Classify macro hash bases by component definition, node occurrence, connection, and compiler domains |
+| `lib/closure.ex` | Semantic projector and new digest type |
+| `lib/workflow/components.ex` | Replace generic fallback with typed identity lookup/projectors |
+| `lib/workflow/component.ex` | Component identity contract and built-in implementations |
+| `lib/workflow.ex` / `private.ex` | Node/Fact occurrence lookup, verified insertion, event application, replay, results |
+| `fact.ex`, `fact_ref.ex`, `facts.ex` | Occurrence/content/payload split |
+| `runnable.ex` | Activation/attempt identity fields |
+| Connection/compiler nodes | Domain-specific definition and occurrence identities |
+| Event modules | Versioned ID/digest fields |
+| Runner Store/Worker | Payload digest persistence and replay bridge |
+| Serializers | Full stable display mapping without `phash2` collapse |
+
+### 15.3 Quantitative estimate
+
+- 136 current shared-helper call sites require classification, though many macro patterns can be migrated through shared builders.
+- 29 integer-only assumptions across 15 files require type/guard changes.
+- nine direct `phash2` sites require removal or explicit display/cache classification.
+- all active vertex insertion sites move behind one verified helper.
+- approximately 13 runtime event modules plus construction/lifecycle event structs carry identity references.
+- Expect multiple reviewable PRs, not one mechanical patch: roughly 20-35 production files and 15-30 test files across S1-S4 before Runtime consumer work.
+- No new hashing dependency; a custom canonical codec is new core code.
+
+## 16. Test and conformance plan
+
+### 16.1 Canonical encoding
+
+- fixed vectors for every supported type/tag;
+- maps with different construction/insertion orders encode identically;
+- list, tuple, atom, and binary domains remain distinct;
+- integer boundaries and floats have exact vectors;
+- unsupported function/PID/port/reference values fail with paths;
+- depth, item, and byte limits fail before unbounded allocation;
+- supported OTP majors produce identical bytes.
+
+### 16.2 Component/artifact identity
+
+- line/file metadata changes do not change component definition digest;
+- semantic AST/binding/port changes do change it;
+- runtime context does not affect it;
+- two names can reference one definition but get different node occurrence IDs;
+- connection selector/path/order semantics are represented exactly;
+- nested workflow artifact digest is stable;
+- custom local-only components receive actionable diagnostics.
+
+### 16.3 Fact and graph semantics
+
+- issue #16 values cannot alias;
+- forced digest conflict returns a typed error;
+- equal payload at two fan-out indexes yields one payload digest and two Fact IDs;
+- retry of one activation reproduces the same Fact ID;
+- a new activation with equal content produces a distinct Fact ID;
+- memoized versus distinct ingress policies are explicit;
+- FactRef hydration preserves IDs and verifies payload digest;
+- component/Fact domain mismatch cannot resolve through Multigraph.
+
+### 16.4 Events, storage, and replay
+
+- event codec/upcaster vectors;
+- full, lean, hybrid, stream, and snapshot-tail replay equivalence;
+- corrupt payload bytes fail digest verification;
+- missing payload is `not_found`/deferred, never decoded as `nil`;
+- migration preserves projections or emits explicit ambiguity;
+- duplicate transaction/command/event/attempt cases use their own IDs;
+- old composite IDs do not enter new streams without an upcast boundary.
+
+### 16.5 Performance
+
+Benchmark separately:
+
+- canonical encoding;
+- SHA-256 over pre-encoded bytes;
+- combined encode+digest;
+- component/artifact construction;
+- small and large payloads;
+- graph insertion/lookup with `%Identity{}` keys;
+- ETS/Mnesia/PostgreSQL key representation;
+- FactRef hydration and digest verification;
+- streaming versus one-shot payload hashing.
+
+Do not evaluate only the multiplier over `phash2`. Record absolute cost in graph construction, per-Fact execution, replay, and payload I/O. The earlier local benchmark measured about 576 ns for a small deterministic ETF+SHA-256 operation and 36 µs for a 64 KiB value; the custom codec requires its own measurements.
+
+The executable [identity benchmark](identity-benchmark.exs) now compares the
+implemented canonical codec plus SHA-256 against `phash2_64_v1`. One local run
+on Elixir 1.19.5 / OTP 28.5 and an AMD Ryzen 7 5800X measured:
+
+| Method | Small Fact basis | 64 KiB Fact basis |
+|---|---:|---:|
+| `phash2_64_v1` | 0.20 µs | 47.89 µs |
+| `runic_canonical_v1` + SHA-256 | 1.97 µs | 44.98 µs |
+
+For small terms the stronger identity path was about 9.7 times slower but still
+under 2 µs in absolute time. For the 64 KiB term it was slightly faster because
+the composite stopgap traverses the input twice. The canonical path allocated
+more memory and consumed more reductions, so these figures are a development
+baseline rather than a substitute for workflow-level benchmarks.
+
+## 17. Acceptance criteria
+
+1. Every public identity declares scheme, version, and domain.
+2. Canonical encoding is stable across the supported OTP-major matrix.
+3. No correctness/public durable identity uses raw `phash2`.
+4. Component definitions and authored node occurrences are distinct concepts and fields.
+5. Fact occurrence, Fact content, and payload digest are distinct concepts and fields.
+6. Equal fan-out payloads preserve causal multiplicity.
+7. Graph insertion compares identity evidence and fails closed on conflict.
+8. Workflow artifacts have reproducible SHA-256 digests.
+9. Runtime activation/attempt/command/transaction/event identities do not reuse graph hashes.
+10. Full and lean replay are equivalent to live projection.
+11. Payload read verifies digest before decode/use.
+12. Serializers never shorten an identity for authoritative lookup.
+13. Old alpha data is explicitly migrated, reset, or rejected; it is never silently mixed.
+14. Custom components declare portable identity documents or are rejected from portable profiles.
+15. Core, property, replay, Store, Runtime reference-model, and consumer fixture tests pass.
+16. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test`, and `git diff --check` pass.
+
+## 18. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Canonical codec becomes an underspecified serialization format | Freeze byte-level vectors and version every domain/schema |
+| Full structs accidentally include local/runtime data | Hash registered identity documents only |
+| SHA-256 cost appears on every graph operation | Compute once at construction/production, cache immutable IDs, stream large payloads |
+| `%Identity{}` Map keys use more memory than integers | Benchmark; allow private indexed projections that verify full identity |
+| Equal content is incorrectly collapsed | Use node/Fact occurrence IDs as graph keys |
+| Occurrence IDs lose determinism on retry | Derive from recorded activation/output coordinates |
+| Names/ordinals make artifact IDs fragile | Prefer explicit stable authored node keys; canonical sort records |
+| Migration invents missing history | Fail with ambiguity diagnostics and preserve old stream read-only |
+| Custom components cannot be canonicalized | Explicit local-only portability profile and projector protocol |
+| Integrity is mistaken for authenticity | Add signatures/MACs separately where trust boundaries require them |
+| Placement hashing is mistaken for authority | Route by execution/work-scope key, but fence mutations in Journal |
+| Stopgap dual semantics persist forever | Time-box upcasters and make composite removal an S6 gate |
+
+## 19. Decisions closed by this plan
+
+1. **Digest algorithm:** SHA-256 for identity scheme version 1.
+2. **Canonical encoding:** Runic-owned restricted deterministic codec, not raw ETF.
+3. **Representation:** typed `%Runic.Identity{}` in Elixir; compact tagged binary on wire/storage.
+4. **Domain separation:** scheme/version/domain included before canonical bytes.
+5. **Graph key:** occurrence identity, not payload digest.
+6. **Multiplicity:** equal content may have distinct occurrences.
+7. **Collision handling:** verified insertion fails closed.
+8. **Custom components:** explicit canonical projector required for portable profiles.
+9. **Migration:** bounded one-time upcast/rebuild or reset; no permanent dual public IDs.
+10. **Placement:** execution/work-scope routing is separate from content identity and Journal fencing.
+
+## 20. Remaining implementation-time details
+
+These details must be frozen in S0 test vectors before code lands:
+
+- exact canonical byte tags and signed integer/float encoding;
+- supported value limits and error-path format;
+- stable authored node-key API and unnamed-node fallback;
+- whether `output_index` is always part of Fact content or only occurrence identity for selected operators;
+- compact SQL column form (`bytea` components versus one encoded binary);
+- event ID derivation inputs after Journal assigns positions;
+- exact migration ordinals for old unnamed repeated nodes/Facts;
+- whether a local pure Workflow allocates an implicit execution namespace at construction or first input.
+
+None of these reopen the identity taxonomy or permit raw `phash2` as a durable fallback.
+
+## 21. Relationship to existing plans
+
+- [Causal Runtime Architecture](causal-runtime-architecture.md) remains the basis for value + ancestry semantics, but content hash is no longer the sole graph occurrence identity.
+- [Checkpointing Implementation Plan](checkpointing-implementation-plan.md) retains FactRef and separate value-storage goals; payload digest replaces causal Fact hash as the immutable value-store key.
+- [Event-sourced Implementation Plan](eventsourced-implementation-plan.md) retains typed events and replay; identity-bearing events become versioned and chronological.
+- [Port Contracts Implementation Plan](port-contracts-implementation-plan.md) remains relevant to adapter seams; future Journal/PayloadStore contracts own distributed correctness.
+- The `zw/dist-runtime` plans already require cryptographic content digests, distinct occurrence IDs, canonical events, Journal fencing, and one-time alpha migration. This document supplies the concrete core identity and canonicalization work needed to satisfy those requirements.

--- a/.docs/sha256-content-identity-implementation-plan.md
+++ b/.docs/sha256-content-identity-implementation-plan.md
@@ -49,6 +49,22 @@ Still proposal, intentionally outside this core stack layer:
 
 The distinction is deliberate: this PR supplies the core identity vocabulary and causal Fact behavior that `main` can validate now without claiming that unmerged Journal or clustered-runtime authority exists.
 
+### Review corrections (2026-09-04)
+
+Projected structs have a dedicated canonical type tag, and closure binding
+projections distinguish external function references from literal tuple data.
+Every binding-dependent macro hash uses that shared projection. Workflow
+artifact nodes include registered semantic projections (including Step and
+Condition contracts); reconstruction retains the recorded authored closure.
+Cytoscape emits full tagged identity strings in its JSON data. `Fact.new/1`
+honors explicit occurrence IDs and rejects invalid or conflicting typed IDs.
+
+These are corrections to the unreleased draft identity contract. Rebuild draft
+artifacts affected by struct encoding, binding projections, or workflow artifact
+documents. Primitive canonical vectors and the existing payload vector remain
+unchanged. Public-path regression coverage lives in
+`test/identity_regression_test.exs`.
+
 ## 1. Why a hash-algorithm swap is insufficient
 
 Replacing this:

--- a/lib/closure.ex
+++ b/lib/closure.ex
@@ -81,6 +81,12 @@ defmodule Runic.Closure do
     %{closure | hash: Identity.project(:component_definition, closure)}
   end
 
+  @doc false
+  @spec identity_bindings(t()) :: map()
+  def identity_bindings(%__MODULE__{} = closure) do
+    Runic.Identity.Projectable.identity_document(closure).bindings
+  end
+
   @doc """
   Evaluates a closure, returning the result and updated bindings.
 

--- a/lib/closure.ex
+++ b/lib/closure.ex
@@ -33,13 +33,13 @@ defmodule Runic.Closure do
   """
 
   alias Runic.ClosureMetadata
-  alias Runic.Workflow.Components
+  alias Runic.Identity
 
   @type t :: %__MODULE__{
           source: Macro.t(),
           bindings: map(),
           metadata: ClosureMetadata.t() | nil,
-          hash: integer() | nil
+          hash: Runic.Identity.t() | nil
         }
 
   @derive {Inspect, only: [:hash, :bindings]}
@@ -63,50 +63,22 @@ defmodule Runic.Closure do
   def new(source, bindings, caller_env_or_metadata)
 
   def new(source, bindings, %Macro.Env{} = caller) when is_map(bindings) do
-    # Validate bindings are serializable
-    validate_bindings!(bindings)
-
-    # Extract metadata from caller environment
-    metadata = ClosureMetadata.from_caller(caller)
-
-    # Compute hash from source and bindings
-    hash = Components.fact_hash({source, bindings})
-
-    %__MODULE__{
-      source: source,
-      bindings: bindings,
-      metadata: metadata,
-      hash: hash
-    }
+    new(source, bindings, ClosureMetadata.from_caller(caller))
   end
 
   def new(source, bindings, %ClosureMetadata{} = metadata) when is_map(bindings) do
-    # Validate bindings are serializable
-    validate_bindings!(bindings)
-
-    # Compute hash from source and bindings
-    hash = Components.fact_hash({source, bindings})
-
-    %__MODULE__{
-      source: source,
-      bindings: bindings,
-      metadata: metadata,
-      hash: hash
-    }
+    build(source, bindings, metadata)
   end
 
   def new(source, bindings, nil) when is_map(bindings) do
-    # No metadata case - for closures without environment dependencies
+    build(source, bindings, nil)
+  end
+
+  defp build(source, bindings, metadata) do
     validate_bindings!(bindings)
 
-    hash = Components.fact_hash({source, bindings})
-
-    %__MODULE__{
-      source: source,
-      bindings: bindings,
-      metadata: nil,
-      hash: hash
-    }
+    closure = %__MODULE__{source: source, bindings: bindings, metadata: metadata}
+    %{closure | hash: Identity.project(:component_definition, closure)}
   end
 
   @doc """

--- a/lib/identity.ex
+++ b/lib/identity.ex
@@ -1,0 +1,144 @@
+defmodule Runic.Identity do
+  @moduledoc """
+  A versioned, domain-separated content identity.
+
+  Identities contain the complete scheme and domain alongside the digest. Two
+  equal digest byte strings in different domains are therefore different keys.
+  Use `digest/2` for canonical identity documents and `derive/2` for identities
+  derived from ordered causal coordinates.
+  """
+
+  alias Runic.Identity.{Canonical, Preimage}
+
+  @enforce_keys [:scheme, :version, :domain, :digest]
+  defstruct scheme: :sha256, version: 1, domain: nil, digest: nil
+
+  @domains [
+    :component_definition,
+    :node_occurrence,
+    :connection_definition,
+    :workflow_artifact,
+    :payload,
+    :fact_content,
+    :fact_occurrence,
+    :execution,
+    :input_command,
+    :activation,
+    :attempt,
+    :transaction,
+    :event,
+    :event_data,
+    :snapshot,
+    :segment
+  ]
+
+  @typedoc "A registered identity domain."
+  @type domain ::
+          :component_definition
+          | :node_occurrence
+          | :connection_definition
+          | :workflow_artifact
+          | :payload
+          | :fact_content
+          | :fact_occurrence
+          | :execution
+          | :input_command
+          | :activation
+          | :attempt
+          | :transaction
+          | :event
+          | :event_data
+          | :snapshot
+          | :segment
+
+  @type t :: %__MODULE__{
+          scheme: :sha256,
+          version: 1,
+          domain: domain(),
+          digest: <<_::256>>
+        }
+
+  @doc "Returns the registered identity domains."
+  @spec domains() :: [domain()]
+  def domains, do: @domains
+
+  @doc "Builds a SHA-256 identity from a canonical identity document."
+  @spec digest(domain(), term()) :: t()
+  def digest(domain, identity_document) do
+    identity_document
+    |> Canonical.encode!()
+    |> then(&digest_bytes(domain, &1))
+  end
+
+  @doc "Derives an identity from an ordered collection of identities and scalars."
+  @spec derive(domain(), term()) :: t()
+  def derive(domain, coordinates), do: digest(domain, {:derive, coordinates})
+
+  @doc "Builds an identity from a value's explicit portable projection."
+  @spec project(domain(), term()) :: t()
+  def project(domain, value) do
+    digest(domain, Runic.Identity.Projectable.identity_document(value))
+  end
+
+  @doc "Builds an identity from bytes already encoded with the canonical codec."
+  @spec digest_bytes(domain(), binary()) :: t()
+  def digest_bytes(domain, canonical_bytes)
+      when domain in @domains and is_binary(canonical_bytes) do
+    %__MODULE__{
+      scheme: :sha256,
+      version: 1,
+      domain: domain,
+      digest: :crypto.hash(:sha256, Preimage.frame_v1(domain, canonical_bytes))
+    }
+  end
+
+  def digest_bytes(domain, canonical_bytes) when is_binary(canonical_bytes) do
+    raise ArgumentError, "unknown Runic identity domain: #{inspect(domain)}"
+  end
+
+  @doc "Returns the compact binary form used inside canonical identity documents."
+  @spec to_binary(t()) :: binary()
+  def to_binary(%__MODULE__{scheme: :sha256, version: version, domain: domain, digest: digest})
+      when byte_size(digest) == 32 do
+    domain_bytes = Atom.to_string(domain)
+
+    <<1, version::unsigned-16, byte_size(domain_bytes)::unsigned-16, domain_bytes::binary,
+      digest::binary>>
+  end
+
+  @doc "Verifies that an identity document reproduces the expected identity."
+  @spec verify(t(), term()) :: :ok | {:error, Runic.Identity.IntegrityError.t()}
+  def verify(%__MODULE__{} = expected, identity_document) do
+    actual = digest(expected.domain, identity_document)
+
+    if actual == expected do
+      :ok
+    else
+      {:error, %Runic.Identity.IntegrityError{expected: expected, actual: actual}}
+    end
+  end
+
+  @doc "Verifies an identity document, raising on mismatch."
+  @spec verify!(t(), term()) :: :ok
+  def verify!(%__MODULE__{} = expected, identity_document) do
+    case verify(expected, identity_document) do
+      :ok -> :ok
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc "Returns the full tagged text representation of an identity."
+  @spec to_string(t()) :: String.t()
+  def to_string(%__MODULE__{} = identity) do
+    "runic:sha256:v#{identity.version}:#{identity.domain}:" <>
+      Base.encode16(identity.digest, case: :lower)
+  end
+
+  @doc "Returns a bounded display string. It must not be used for lookup."
+  @spec short_string(t(), pos_integer()) :: String.t()
+  def short_string(%__MODULE__{} = identity, length \\ 20)
+      when is_integer(length) and length > 0 do
+    digest = identity.digest |> Base.encode16(case: :lower) |> binary_part(0, min(length, 64))
+    "#{identity.domain}_#{digest}"
+  end
+end

--- a/lib/identity/canonical.ex
+++ b/lib/identity/canonical.ex
@@ -1,0 +1,160 @@
+defmodule Runic.Identity.Canonical do
+  @moduledoc """
+  Restricted deterministic encoding used by Runic identity scheme version 1.
+
+  The format uses explicit type tags and length framing. Map entries are sorted
+  by their encoded key bytes, making identity independent of map construction
+  order and BEAM map iteration order. Process-local and executable terms are
+  rejected rather than assigned misleading portable identities.
+  """
+
+  import Bitwise
+
+  alias Runic.Identity
+  alias Runic.Identity.CanonicalError
+
+  @default_max_depth 64
+  @default_max_items 100_000
+  @default_max_bytes 16 * 1024 * 1024
+
+  @type option ::
+          {:max_depth, pos_integer()}
+          | {:max_items, pos_integer()}
+          | {:max_bytes, pos_integer()}
+
+  @doc "Encodes an identity-safe value into canonical version 1 bytes."
+  @spec encode!(term(), [option()]) :: binary()
+  def encode!(term, opts \\ []) do
+    limits = %{
+      max_depth: Keyword.get(opts, :max_depth, @default_max_depth),
+      max_items: Keyword.get(opts, :max_items, @default_max_items),
+      max_bytes: Keyword.get(opts, :max_bytes, @default_max_bytes)
+    }
+
+    {encoded, items} = encode(term, [], 0, limits)
+
+    if items > limits.max_items do
+      raise CanonicalError, reason: {:limit, :item_count, items}
+    end
+
+    if byte_size(encoded) > limits.max_bytes do
+      raise CanonicalError, reason: {:limit, :byte_size, byte_size(encoded)}
+    end
+
+    encoded
+  end
+
+  defp encode(_term, path, depth, %{max_depth: max_depth}) when depth > max_depth do
+    raise CanonicalError, reason: {:limit, :depth, depth}, path: Enum.reverse(path)
+  end
+
+  defp encode(nil, _path, _depth, _limits), do: {<<0x00>>, 1}
+  defp encode(false, _path, _depth, _limits), do: {<<0x01>>, 1}
+  defp encode(true, _path, _depth, _limits), do: {<<0x02>>, 1}
+
+  defp encode(integer, _path, _depth, _limits) when is_integer(integer) do
+    {frame(0x10, Integer.to_string(integer)), 1}
+  end
+
+  defp encode(float, path, _depth, _limits) when is_float(float) do
+    <<bits::unsigned-64>> = <<float::float-64>>
+    exponent = bits >>> 52 &&& 0x7FF
+
+    if exponent == 0x7FF do
+      raise CanonicalError, reason: {:unsupported, :non_finite_float}, path: Enum.reverse(path)
+    end
+
+    {<<0x11, bits::unsigned-64>>, 1}
+  end
+
+  defp encode(binary, _path, _depth, _limits) when is_binary(binary) do
+    {frame(0x20, binary), 1}
+  end
+
+  defp encode(atom, _path, _depth, _limits) when is_atom(atom) do
+    {frame(0x21, Atom.to_string(atom)), 1}
+  end
+
+  defp encode(%Identity{} = identity, _path, _depth, _limits) do
+    {frame(0x40, Identity.to_binary(identity)), 1}
+  end
+
+  defp encode(%module{} = value, path, depth, limits) do
+    document =
+      try do
+        Runic.Identity.Projectable.identity_document(value)
+      rescue
+        Protocol.UndefinedError ->
+          raise CanonicalError, reason: {:unsupported, module}, path: Enum.reverse(path)
+      end
+
+    encode({:projected, module, document}, path, depth, limits)
+  end
+
+  defp encode(list, path, depth, limits) when is_list(list) do
+    list
+    |> Enum.with_index()
+    |> Enum.map_reduce(1, fn {value, index}, items ->
+      {encoded, child_items} = encode(value, [index | path], depth + 1, limits)
+      next_items = items + child_items
+      ensure_item_limit!(next_items, [index | path], limits)
+      {encoded, next_items}
+    end)
+    |> then(fn {encoded, items} -> {sequence(0x30, encoded), items} end)
+  end
+
+  defp encode(tuple, path, depth, limits) when is_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> Enum.with_index()
+    |> Enum.map_reduce(1, fn {value, index}, items ->
+      {encoded, child_items} = encode(value, [index | path], depth + 1, limits)
+      next_items = items + child_items
+      ensure_item_limit!(next_items, [index | path], limits)
+      {encoded, next_items}
+    end)
+    |> then(fn {encoded, items} -> {sequence(0x31, encoded), items} end)
+  end
+
+  defp encode(map, path, depth, limits) when is_map(map) and not is_struct(map) do
+    map
+    |> Enum.map(fn {key, value} ->
+      {encoded_key, key_items} = encode(key, [:key | path], depth + 1, limits)
+      {encoded_value, value_items} = encode(value, [key | path], depth + 1, limits)
+      {encoded_key, encoded_value, key_items + value_items}
+    end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map_reduce(1, fn {key, value, child_items}, items ->
+      next_items = items + child_items
+      ensure_item_limit!(next_items, path, limits)
+      {sequence(0x32, [key, value]), next_items}
+    end)
+    |> then(fn {entries, items} -> {sequence(0x33, entries), items} end)
+  end
+
+  defp encode(term, path, _depth, _limits) do
+    type =
+      cond do
+        is_function(term) -> :function
+        is_pid(term) -> :pid
+        is_port(term) -> :port
+        is_reference(term) -> :reference
+        true -> :term
+      end
+
+    raise CanonicalError, reason: {:unsupported, type}, path: Enum.reverse(path)
+  end
+
+  defp frame(tag, bytes), do: <<tag, byte_size(bytes)::unsigned-64, bytes::binary>>
+
+  defp ensure_item_limit!(items, path, %{max_items: max_items}) when items > max_items do
+    raise CanonicalError, reason: {:limit, :item_count, items}, path: Enum.reverse(path)
+  end
+
+  defp ensure_item_limit!(_items, _path, _limits), do: :ok
+
+  defp sequence(tag, encoded_items) do
+    payload = Enum.map(encoded_items, &<<byte_size(&1)::unsigned-64, &1::binary>>)
+    IO.iodata_to_binary([<<tag, length(encoded_items)::unsigned-64>>, payload])
+  end
+end

--- a/lib/identity/canonical.ex
+++ b/lib/identity/canonical.ex
@@ -88,7 +88,8 @@ defmodule Runic.Identity.Canonical do
           raise CanonicalError, reason: {:unsupported, module}, path: Enum.reverse(path)
       end
 
-    encode({:projected, module, document}, path, depth, limits)
+    {encoded, items} = encode({module, document}, path, depth, limits)
+    {frame(0x41, encoded), items}
   end
 
   defp encode(list, path, depth, limits) when is_list(list) do

--- a/lib/identity/canonical_error.ex
+++ b/lib/identity/canonical_error.ex
@@ -1,0 +1,23 @@
+defmodule Runic.Identity.CanonicalError do
+  @moduledoc "Raised when a value cannot be represented by the canonical identity codec."
+
+  defexception [:reason, path: []]
+
+  @type t :: %__MODULE__{reason: term(), path: [term()]}
+
+  @impl Exception
+  def message(%__MODULE__{} = error) do
+    "cannot canonically encode identity document at #{format_path(error.path)}: " <>
+      format_reason(error.reason)
+  end
+
+  defp format_path([]), do: "$"
+
+  defp format_path(path) do
+    Enum.reduce(path, "$", fn segment, acc -> acc <> "[#{inspect(segment)}]" end)
+  end
+
+  defp format_reason({:unsupported, type}), do: "unsupported #{type} value"
+  defp format_reason({:limit, name, value}), do: "#{name} limit exceeded (#{value})"
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/lib/identity/inspect.ex
+++ b/lib/identity/inspect.ex
@@ -1,0 +1,7 @@
+defimpl Inspect, for: Runic.Identity do
+  import Inspect.Algebra
+
+  def inspect(identity, _opts) do
+    concat(["#Runic.Identity<", Runic.Identity.short_string(identity), ">"])
+  end
+end

--- a/lib/identity/integrity_error.ex
+++ b/lib/identity/integrity_error.ex
@@ -1,0 +1,13 @@
+defmodule Runic.Identity.IntegrityError do
+  @moduledoc "Raised when content does not reproduce its declared Runic identity."
+
+  defexception [:expected, :actual]
+
+  @type t :: %__MODULE__{expected: Runic.Identity.t(), actual: Runic.Identity.t()}
+
+  @impl Exception
+  def message(%__MODULE__{} = error) do
+    "Runic identity verification failed: expected #{Runic.Identity.short_string(error.expected)}, " <>
+      "got #{Runic.Identity.short_string(error.actual)}"
+  end
+end

--- a/lib/identity/preimage.ex
+++ b/lib/identity/preimage.ex
@@ -1,0 +1,14 @@
+defmodule Runic.Identity.Preimage do
+  @moduledoc false
+
+  @magic "runic-id"
+  @version 1
+
+  @spec frame_v1(atom(), binary()) :: binary()
+  def frame_v1(domain, canonical_bytes) when is_atom(domain) and is_binary(canonical_bytes) do
+    domain_bytes = Atom.to_string(domain)
+
+    <<@magic::binary, 0, @version::unsigned-16, byte_size(domain_bytes)::unsigned-16,
+      domain_bytes::binary, byte_size(canonical_bytes)::unsigned-64, canonical_bytes::binary>>
+  end
+end

--- a/lib/identity/projectable.ex
+++ b/lib/identity/projectable.ex
@@ -1,0 +1,13 @@
+defprotocol Runic.Identity.Projectable do
+  @moduledoc """
+  Projects a value into a portable, canonical identity document.
+
+  Custom components opt in explicitly. Live structs and compiled functions are
+  never hashed implicitly as portable definitions.
+  """
+
+  @fallback_to_any true
+
+  @spec identity_document(t()) :: term()
+  def identity_document(value)
+end

--- a/lib/identity/projectors/any.ex
+++ b/lib/identity/projectors/any.ex
@@ -1,0 +1,8 @@
+defimpl Runic.Identity.Projectable, for: Any do
+  def identity_document(value) do
+    raise Protocol.UndefinedError,
+      protocol: Runic.Identity.Projectable,
+      value: value,
+      description: "the value has no portable Runic identity projection"
+  end
+end

--- a/lib/identity/projectors/closure.ex
+++ b/lib/identity/projectors/closure.ex
@@ -28,7 +28,8 @@ defimpl Runic.Identity.Projectable, for: Runic.Closure do
   defp project_binding(list) when is_list(list), do: Enum.map(list, &project_binding/1)
 
   defp project_binding(tuple) when is_tuple(tuple) do
-    tuple |> Tuple.to_list() |> Enum.map(&project_binding/1) |> List.to_tuple()
+    # Preserve the distinction between literal tuple data and MFA references.
+    {:tuple, tuple |> Tuple.to_list() |> Enum.map(&project_binding/1)}
   end
 
   defp project_binding(map) when is_map(map) and not is_struct(map) do

--- a/lib/identity/projectors/closure.ex
+++ b/lib/identity/projectors/closure.ex
@@ -1,0 +1,39 @@
+defimpl Runic.Identity.Projectable, for: Runic.Closure do
+  def identity_document(closure) do
+    %{
+      kind: :closure,
+      version: 1,
+      source: closure.source,
+      bindings: project_bindings(closure.bindings)
+    }
+  end
+
+  defp project_bindings(map) when is_map(map) and not is_struct(map) do
+    Map.new(map, fn {key, value} -> {key, project_binding(value)} end)
+  end
+
+  defp project_binding(function) when is_function(function) do
+    info = Function.info(function)
+
+    case Keyword.fetch!(info, :type) do
+      :external ->
+        {:mfa, Keyword.fetch!(info, :module), Keyword.fetch!(info, :name),
+         Keyword.fetch!(info, :arity)}
+
+      :local ->
+        function
+    end
+  end
+
+  defp project_binding(list) when is_list(list), do: Enum.map(list, &project_binding/1)
+
+  defp project_binding(tuple) when is_tuple(tuple) do
+    tuple |> Tuple.to_list() |> Enum.map(&project_binding/1) |> List.to_tuple()
+  end
+
+  defp project_binding(map) when is_map(map) and not is_struct(map) do
+    Map.new(map, fn {key, value} -> {project_binding(key), project_binding(value)} end)
+  end
+
+  defp project_binding(value), do: value
+end

--- a/lib/identity/projectors/condition.ex
+++ b/lib/identity/projectors/condition.ex
@@ -16,6 +16,9 @@ defimpl Runic.Identity.Projectable, for: Runic.Workflow.Condition do
   end
 
   defp executable_document(condition) do
-    %{local_work_digest: condition.work_hash || condition.hash}
+    %{
+      local_work_digest:
+        condition.work_hash || Runic.Workflow.Components.work_hash(condition.work)
+    }
   end
 end

--- a/lib/identity/projectors/condition.ex
+++ b/lib/identity/projectors/condition.ex
@@ -1,0 +1,21 @@
+defimpl Runic.Identity.Projectable, for: Runic.Workflow.Condition do
+  alias Runic.Identity.Projectable
+
+  def identity_document(condition) do
+    %{
+      kind: :condition,
+      version: 1,
+      executable: executable_document(condition),
+      arity: condition.arity,
+      meta_requirements: condition.meta_refs
+    }
+  end
+
+  defp executable_document(%{closure: %Runic.Closure{} = closure}) do
+    Projectable.identity_document(closure)
+  end
+
+  defp executable_document(condition) do
+    %{local_work_digest: condition.work_hash || condition.hash}
+  end
+end

--- a/lib/identity/projectors/range.ex
+++ b/lib/identity/projectors/range.ex
@@ -1,0 +1,5 @@
+defimpl Runic.Identity.Projectable, for: Range do
+  def identity_document(range) do
+    %{first: range.first, last: range.last, step: range.step}
+  end
+end

--- a/lib/identity/projectors/step.ex
+++ b/lib/identity/projectors/step.ex
@@ -17,7 +17,9 @@ defimpl Runic.Identity.Projectable, for: Runic.Workflow.Step do
     Projectable.identity_document(closure)
   end
 
-  defp executable_document(step), do: %{local_work_digest: step.work_hash || step.hash}
+  defp executable_document(step) do
+    %{local_work_digest: step.work_hash || Runic.Workflow.Components.work_hash(step.work)}
+  end
 
   defp struct_document(nil), do: nil
   defp struct_document(%_{} = value), do: Map.from_struct(value)

--- a/lib/identity/projectors/step.ex
+++ b/lib/identity/projectors/step.ex
@@ -1,0 +1,25 @@
+defimpl Runic.Identity.Projectable, for: Runic.Workflow.Step do
+  alias Runic.Identity.Projectable
+
+  def identity_document(step) do
+    %{
+      kind: :step,
+      version: 1,
+      executable: executable_document(step),
+      call_contract: struct_document(step.call_contract),
+      inputs: step.inputs,
+      outputs: step.outputs,
+      meta_requirements: step.meta_refs
+    }
+  end
+
+  defp executable_document(%{closure: %Runic.Closure{} = closure}) do
+    Projectable.identity_document(closure)
+  end
+
+  defp executable_document(step), do: %{local_work_digest: step.work_hash || step.hash}
+
+  defp struct_document(nil), do: nil
+  defp struct_document(%_{} = value), do: Map.from_struct(value)
+  defp struct_document(value), do: value
+end

--- a/lib/identity/string_chars.ex
+++ b/lib/identity/string_chars.ex
@@ -1,0 +1,3 @@
+defimpl String.Chars, for: Runic.Identity do
+  def to_string(identity), do: Runic.Identity.to_string(identity)
+end

--- a/lib/runic.ex
+++ b/lib/runic.ex
@@ -184,7 +184,9 @@ defmodule Runic do
         step_hash = closure.hash
         # Work hash is based on NORMALIZED AST + bindings for deterministic content addressing
         work_hash =
-          Components.fact_hash({unquote(Macro.escape(normalized_work)), closure.bindings})
+          Components.fact_hash(
+            {unquote(Macro.escape(normalized_work)), Closure.identity_bindings(closure)}
+          )
 
         Step.new(
           work: unquote(final_work),
@@ -283,7 +285,9 @@ defmodule Runic do
         step_hash = closure.hash
 
         work_hash =
-          Components.fact_hash({unquote(Macro.escape(normalized_work)), closure.bindings})
+          Components.fact_hash(
+            {unquote(Macro.escape(normalized_work)), Closure.identity_bindings(closure)}
+          )
 
         step_name =
           if unquote(base_name) do
@@ -364,7 +368,9 @@ defmodule Runic do
         step_hash = closure.hash
 
         work_hash =
-          Components.fact_hash({unquote(Macro.escape(normalized_work)), closure.bindings})
+          Components.fact_hash(
+            {unquote(Macro.escape(normalized_work)), Closure.identity_bindings(closure)}
+          )
 
         step_name =
           if unquote(base_name) do
@@ -485,7 +491,9 @@ defmodule Runic do
         condition_hash = closure.hash
 
         work_hash =
-          Components.fact_hash({unquote(Macro.escape(normalized_work)), closure.bindings})
+          Components.fact_hash(
+            {unquote(Macro.escape(normalized_work)), Closure.identity_bindings(closure)}
+          )
 
         Condition.new(
           work: unquote(final_work),
@@ -601,7 +609,9 @@ defmodule Runic do
             condition_hash = closure.hash
 
             work_hash =
-              Components.fact_hash({unquote(Macro.escape(normalized_work)), closure.bindings})
+              Components.fact_hash(
+                {unquote(Macro.escape(normalized_work)), Closure.identity_bindings(closure)}
+              )
 
             condition_name =
               if unquote(base_name) do
@@ -3844,7 +3854,8 @@ defmodule Runic do
 
         fan_in_hash =
           Components.fact_hash(
-            {unquote(acc), unquote(Macro.escape(normalized_reducer)), closure.bindings}
+            {unquote(acc), unquote(Macro.escape(normalized_reducer)),
+             Closure.identity_bindings(closure)}
           )
 
         reduce_hash = closure.hash
@@ -3984,7 +3995,8 @@ defmodule Runic do
 
         reduce_hash =
           Components.fact_hash(
-            {unquote(init), unquote(Macro.escape(normalized_reducer)), closure.bindings}
+            {unquote(init), unquote(Macro.escape(normalized_reducer)),
+             Closure.identity_bindings(closure)}
           )
 
         accumulator_name =

--- a/lib/runic.ex
+++ b/lib/runic.ex
@@ -4,6 +4,7 @@ defmodule Runic do
 
   alias Runic.Closure
   alias Runic.ClosureMetadata
+  alias Runic.Identity
   alias Runic.Workflow.CompilationUtils
   alias Runic.Workflow.Accumulator
   alias Runic.Workflow.Aggregate
@@ -24,6 +25,14 @@ defmodule Runic do
   defp default_component_name(component_kind, hash) do
     "#{component_kind}_#{hash}"
   end
+
+  defp identity_ast(%Identity{} = identity), do: Macro.escape(identity)
+
+  defp identity_ast({_, metadata, arguments} = ast)
+       when is_list(metadata) and (is_list(arguments) or is_atom(arguments)),
+       do: ast
+
+  defp identity_ast(term), do: Macro.escape(term)
 
   @doc """
   Creates a `%Step{}`: a basic lambda expression that can be added to a workflow.
@@ -158,8 +167,8 @@ defmodule Runic do
           work: unquote(final_work),
           closure: unquote(closure),
           name: unquote(default_component_name("step", step_hash)),
-          hash: unquote(step_hash),
-          work_hash: unquote(work_hash),
+          hash: unquote(identity_ast(step_hash)),
+          work_hash: unquote(identity_ast(work_hash)),
           inputs: nil,
           outputs: nil,
           meta_refs: unquote(escaped_meta_refs)
@@ -209,8 +218,8 @@ defmodule Runic do
         work: unquote(work),
         closure: unquote(closure),
         name: unquote(default_component_name("step", step_hash)),
-        hash: unquote(step_hash),
-        work_hash: unquote(work_hash),
+        hash: unquote(identity_ast(step_hash)),
+        work_hash: unquote(identity_ast(work_hash)),
         inputs: nil,
         outputs: nil
       )
@@ -258,8 +267,8 @@ defmodule Runic do
           work: unquote(final_work),
           closure: unquote(closure),
           name: unquote(step_name),
-          hash: unquote(step_hash),
-          work_hash: unquote(work_hash),
+          hash: unquote(identity_ast(step_hash)),
+          work_hash: unquote(identity_ast(work_hash)),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
           meta_refs: unquote(escaped_meta_refs)
@@ -339,8 +348,8 @@ defmodule Runic do
           work: unquote(final_work),
           closure: unquote(closure),
           name: unquote(step_name),
-          hash: unquote(step_hash),
-          work_hash: unquote(work_hash),
+          hash: unquote(identity_ast(step_hash)),
+          work_hash: unquote(identity_ast(work_hash)),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
           meta_refs: unquote(escaped_meta_refs)
@@ -462,8 +471,8 @@ defmodule Runic do
           work: unquote(final_work),
           closure: unquote(closure),
           name: unquote(default_component_name("condition", condition_hash)),
-          hash: unquote(condition_hash),
-          work_hash: unquote(work_hash),
+          hash: unquote(identity_ast(condition_hash)),
+          work_hash: unquote(identity_ast(work_hash)),
           arity: unquote(arity),
           meta_refs: unquote(escaped_meta_refs)
         )
@@ -511,8 +520,8 @@ defmodule Runic do
         work: work_fn,
         closure: unquote(closure),
         name: unquote(default_component_name("condition", condition_hash)),
-        hash: unquote(condition_hash),
-        work_hash: unquote(work_hash),
+        hash: unquote(identity_ast(condition_hash)),
+        work_hash: unquote(identity_ast(work_hash)),
         arity: arity
       )
     end
@@ -577,8 +586,8 @@ defmodule Runic do
               work: unquote(final_work),
               closure: unquote(closure),
               name: unquote(condition_name),
-              hash: unquote(condition_hash),
-              work_hash: unquote(work_hash),
+              hash: unquote(identity_ast(condition_hash)),
+              work_hash: unquote(identity_ast(work_hash)),
               arity: unquote(arity),
               meta_refs: unquote(escaped_meta_refs)
             )
@@ -634,8 +643,8 @@ defmodule Runic do
             work: work_fn,
             closure: unquote(closure),
             name: unquote(condition_name),
-            hash: unquote(condition_hash),
-            work_hash: unquote(work_hash),
+            hash: unquote(identity_ast(condition_hash)),
+            work_hash: unquote(identity_ast(work_hash)),
             arity: arity
           )
         end
@@ -1159,9 +1168,9 @@ defmodule Runic do
           name: unquote(rule_name),
           arity: unquote(arity),
           workflow: unquote(workflow),
-          hash: unquote(rule_hash),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(rule_hash)),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           closure: unquote(closure)
         }
       end
@@ -1176,8 +1185,8 @@ defmodule Runic do
           arity: unquote(arity),
           workflow: unquote(workflow),
           hash: rule_hash,
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           closure: closure
         }
       end
@@ -1263,9 +1272,9 @@ defmodule Runic do
           name: unquote(rule_name),
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
-          hash: unquote(rule_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
+          hash: unquote(identity_ast(rule_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs])
@@ -1287,8 +1296,8 @@ defmodule Runic do
           name: rule_name,
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           hash: rule_hash,
           closure: closure,
           inputs: unquote(rewritten_opts[:inputs]),
@@ -1402,9 +1411,9 @@ defmodule Runic do
           name: unquote(rule_name),
           arity: unquote(arity),
           workflow: unquote(workflow),
-          hash: unquote(rule_hash),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(rule_hash)),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs])
@@ -1427,8 +1436,8 @@ defmodule Runic do
           arity: unquote(arity),
           workflow: unquote(workflow),
           hash: rule_hash,
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           closure: closure,
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs])
@@ -1727,7 +1736,7 @@ defmodule Runic do
         reactor_rules: sm_reactor_rules,
         workflow: unquote(workflow_ast),
         source: unquote(Macro.escape(source)),
-        hash: unquote(state_machine_hash),
+        hash: unquote(identity_ast(state_machine_hash)),
         bindings: unquote(bindings),
         inputs: unquote(inputs),
         outputs: unquote(outputs)
@@ -1825,7 +1834,7 @@ defmodule Runic do
         compensation_rules: [],
         workflow: unquote(workflow_ast),
         source: unquote(Macro.escape(source)),
-        hash: unquote(saga_hash),
+        hash: unquote(identity_ast(saga_hash)),
         inputs: unquote(inputs),
         outputs: unquote(outputs)
       }
@@ -2030,7 +2039,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(init_ast),
         reducer: unquote(reducer_ast),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(saga_name)}_accumulator",
         meta_refs: []
       }
@@ -2097,7 +2106,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -2105,7 +2114,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -2120,7 +2129,10 @@ defmodule Runic do
         name: rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -2165,7 +2177,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -2173,7 +2185,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -2188,7 +2200,10 @@ defmodule Runic do
         name: rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -2329,7 +2344,7 @@ defmodule Runic do
         command_rules: agg_command_rules,
         workflow: unquote(workflow_ast),
         source: unquote(Macro.escape(source)),
-        hash: unquote(agg_hash)
+        hash: unquote(identity_ast(agg_hash))
       }
     end
   end
@@ -2479,7 +2494,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(literal_init_ast),
         reducer: unquote(reducer_ast),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(agg_name)}_accumulator",
         meta_refs: []
       }
@@ -2530,7 +2545,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: unquote(condition_arity),
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -2538,7 +2553,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -2551,7 +2566,10 @@ defmodule Runic do
         name: cmd_rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -2761,7 +2779,7 @@ defmodule Runic do
         completion_rule: pm_completion_rule,
         workflow: unquote(workflow_ast),
         source: unquote(Macro.escape(source)),
-        hash: unquote(pm_hash),
+        hash: unquote(identity_ast(pm_hash)),
         inputs: unquote(inputs),
         outputs: unquote(outputs)
       }
@@ -2893,7 +2911,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(literal_init_ast),
         reducer: unquote(reducer_ast),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(pm_name)}_accumulator",
         meta_refs: []
       }
@@ -2971,7 +2989,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(condition_fn),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 1,
           meta_refs: []
         )
@@ -2979,7 +2997,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -2992,7 +3010,10 @@ defmodule Runic do
         name: unquote(rule_name),
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -3037,7 +3058,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -3045,7 +3066,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(reaction_fn),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: []
         )
 
@@ -3060,7 +3081,10 @@ defmodule Runic do
         name: rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -3206,7 +3230,7 @@ defmodule Runic do
         entry_rules: fsm_entry_rules,
         workflow: unquote(workflow_ast),
         source: unquote(Macro.escape(source)),
-        hash: unquote(fsm_hash),
+        hash: unquote(identity_ast(fsm_hash)),
         inputs: unquote(inputs),
         outputs: unquote(outputs)
       }
@@ -3328,7 +3352,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(init_ast),
         reducer: unquote(reducer_ast),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(fsm_name)}_accumulator",
         meta_refs: []
       }
@@ -3388,7 +3412,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -3396,7 +3420,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(reaction_fn),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: []
         )
 
@@ -3409,7 +3433,10 @@ defmodule Runic do
         name: unquote(rule_name),
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -3458,7 +3485,7 @@ defmodule Runic do
       entry_condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -3466,7 +3493,7 @@ defmodule Runic do
       entry_reaction =
         Step.new(
           work: unquote(reaction_fn),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: []
         )
 
@@ -3479,7 +3506,10 @@ defmodule Runic do
         name: unquote(rule_name),
         arity: 1,
         workflow: entry_rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: entry_condition.hash,
         reaction_hash: entry_reaction.hash
       }
@@ -3643,7 +3673,7 @@ defmodule Runic do
         %Runic.Workflow.Map{
           name: unquote(map_name),
           pipeline: unquote(map_pipeline),
-          hash: unquote(map_hash),
+          hash: unquote(identity_ast(map_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs])
@@ -3791,12 +3821,12 @@ defmodule Runic do
       quote do
         %Runic.Workflow.Reduce{
           name: unquote(reduce_name),
-          hash: unquote(reduce_hash),
+          hash: unquote(identity_ast(reduce_hash)),
           fan_in: %FanIn{
             map: unquote(map_to_reduce),
             init: fn -> unquote(acc) end,
             reducer: unquote(final_reducer),
-            hash: unquote(fan_in_hash),
+            hash: unquote(identity_ast(fan_in_hash)),
             name: unquote(reduce_name),
             meta_refs: unquote(escaped_meta_refs)
           },
@@ -3936,8 +3966,8 @@ defmodule Runic do
           name: unquote(accumulator_name),
           init: fn -> unquote(init) end,
           reducer: unquote(final_reducer),
-          hash: unquote(accumulator_hash),
-          reduce_hash: unquote(reduce_hash),
+          hash: unquote(identity_ast(accumulator_hash)),
+          reduce_hash: unquote(identity_ast(reduce_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
@@ -4358,7 +4388,7 @@ defmodule Runic do
     fan_out =
       quote do
         %FanOut{
-          hash: unquote(fan_out_hash),
+          hash: unquote(identity_ast(fan_out_hash)),
           name: unquote(name)
         }
       end
@@ -4370,7 +4400,7 @@ defmodule Runic do
       |> Workflow.add_step(unquote(fan_out))
       |> Workflow.add_step(unquote(fan_out), unquote(step))
 
-      # |> Workflow.add(unquote(step), to: unquote(fan_out_hash))
+      # |> Workflow.add(unquote(step), to: unquote(identity_ast(fan_out_hash)))
     end
   end
 
@@ -4380,7 +4410,7 @@ defmodule Runic do
     fan_out =
       quote do
         %FanOut{
-          hash: unquote(fan_out_hash),
+          hash: unquote(identity_ast(fan_out_hash)),
           name: unquote(name)
         }
       end
@@ -4390,7 +4420,7 @@ defmodule Runic do
     quote do
       unquote(wrk_expression)
       |> Workflow.add_step(unquote(fan_out))
-      |> Workflow.add(unquote(step), to: unquote(fan_out_hash))
+      |> Workflow.add(unquote(step), to: unquote(identity_ast(fan_out_hash)))
     end
   end
 
@@ -4404,7 +4434,7 @@ defmodule Runic do
     fan_out =
       quote do
         %FanOut{
-          hash: unquote(fan_out_hash),
+          hash: unquote(identity_ast(fan_out_hash)),
           name: unquote(name)
         }
       end
@@ -4416,13 +4446,20 @@ defmodule Runic do
 
     parent_hashes = Enum.map(parent_steps_with_hashes, &elem(&1, 0))
 
+    parent_steps_with_hashes_ast =
+      Enum.map(parent_steps_with_hashes, fn {hash, step_ast} ->
+        quote do
+          {unquote(identity_ast(hash)), unquote(step_ast)}
+        end
+      end)
+
     join_hash = Components.fact_hash(Enum.map(parent_steps_with_hashes, &elem(&1, 0)))
 
     join =
       quote do
         %Join{
-          hash: unquote(join_hash),
-          joins: unquote(parent_hashes)
+          hash: unquote(identity_ast(join_hash)),
+          joins: unquote(identity_ast(parent_hashes))
         }
       end
 
@@ -4431,12 +4468,16 @@ defmodule Runic do
         unquote(wrk_expression)
         |> Workflow.add_step(unquote(fan_out))
         |> then(fn wrk_expression ->
-          Enum.reduce(unquote(parent_steps_with_hashes), wrk_expression, fn {_, join_step}, acc ->
+          Enum.reduce([unquote_splicing(parent_steps_with_hashes_ast)], wrk_expression, fn {_,
+                                                                                            join_step},
+                                                                                           acc ->
             Workflow.add_step(acc, unquote(fan_out), join_step)
           end)
         end)
         |> then(fn wrk_expression ->
-          Enum.reduce(unquote(parent_steps_with_hashes), wrk_expression, fn {_, join_step}, acc ->
+          Enum.reduce([unquote_splicing(parent_steps_with_hashes_ast)], wrk_expression, fn {_,
+                                                                                            join_step},
+                                                                                           acc ->
             Workflow.add_step(acc, join_step, unquote(join))
           end)
         end)
@@ -4451,7 +4492,9 @@ defmodule Runic do
 
       quote generated: true do
         unquote(wrk_acc)
-        |> Workflow.add(unquote(dependent_pipeline_workflow), to: unquote(join_hash))
+        |> Workflow.add(unquote(dependent_pipeline_workflow),
+          to: unquote(identity_ast(join_hash))
+        )
       end
     end)
   end
@@ -4466,7 +4509,7 @@ defmodule Runic do
     fan_out =
       quote do
         %FanOut{
-          hash: unquote(fan_out_hash),
+          hash: unquote(identity_ast(fan_out_hash)),
           name: unquote(name)
         }
       end
@@ -4477,7 +4520,7 @@ defmodule Runic do
       quote generated: true do
         unquote(wrk_expression)
         |> Workflow.add_step(unquote(fan_out))
-        |> Workflow.add(unquote(step), to: unquote(fan_out_hash))
+        |> Workflow.add(unquote(step), to: unquote(identity_ast(fan_out_hash)))
       end
 
     dependent_pipeline_workflow =
@@ -4499,7 +4542,7 @@ defmodule Runic do
     fan_out =
       quote do
         %FanOut{
-          hash: unquote(fan_out_hash),
+          hash: unquote(identity_ast(fan_out_hash)),
           name: unquote(name)
         }
       end
@@ -4516,7 +4559,9 @@ defmodule Runic do
 
       quote generated: true do
         unquote(wrk_acc)
-        |> Workflow.add(unquote(dependent_pipeline_workflow), to: unquote(fan_out_hash))
+        |> Workflow.add(unquote(dependent_pipeline_workflow),
+          to: unquote(identity_ast(fan_out_hash))
+        )
       end
     end)
   end
@@ -4532,7 +4577,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(init),
         reducer: unquote(reducer),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(sm_name)}_accumulator",
         meta_refs: unquote(meta_refs)
       }
@@ -4546,7 +4591,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(init),
         reducer: unquote(reducer),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(sm_name)}_accumulator",
         meta_refs: unquote(meta_refs)
       }
@@ -4566,7 +4611,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(init_fun),
         reducer: unquote(reducer),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(sm_name)}_accumulator",
         meta_refs: unquote(meta_refs)
       }
@@ -4585,7 +4630,7 @@ defmodule Runic do
       %Accumulator{
         init: unquote(literal_init_ast),
         reducer: unquote(reducer),
-        hash: unquote(acc_hash),
+        hash: unquote(identity_ast(acc_hash)),
         name: :"#{unquote(sm_name)}_accumulator",
         meta_refs: unquote(meta_refs)
       }
@@ -4697,7 +4742,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -4705,7 +4750,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -4718,7 +4763,10 @@ defmodule Runic do
         name: sm_rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -4806,7 +4854,7 @@ defmodule Runic do
       condition =
         Condition.new(
           work: unquote(final_condition),
-          hash: unquote(condition_hash),
+          hash: unquote(identity_ast(condition_hash)),
           arity: 2,
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -4814,7 +4862,7 @@ defmodule Runic do
       reaction =
         Step.new(
           work: unquote(final_reaction),
-          hash: unquote(reaction_hash),
+          hash: unquote(identity_ast(reaction_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
 
@@ -4827,7 +4875,10 @@ defmodule Runic do
         name: sm_rule_name,
         arity: 1,
         workflow: rule_workflow,
-        hash: Components.fact_hash({unquote(condition_hash), unquote(reaction_hash)}),
+        hash:
+          Components.fact_hash(
+            {unquote(identity_ast(condition_hash)), unquote(identity_ast(reaction_hash))}
+          ),
         condition_hash: condition.hash,
         reaction_hash: reaction.hash
       }
@@ -5035,9 +5086,9 @@ defmodule Runic do
           name: unquote(rule_name),
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
-          hash: unquote(rule_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
+          hash: unquote(identity_ast(rule_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs])
@@ -5059,8 +5110,8 @@ defmodule Runic do
           name: rule_name,
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           hash: rule_hash,
           closure: closure,
           inputs: unquote(rewritten_opts[:inputs]),
@@ -5154,9 +5205,9 @@ defmodule Runic do
           name: unquote(rule_name),
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
-          hash: unquote(rule_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
+          hash: unquote(identity_ast(rule_hash)),
           closure: unquote(closure),
           inputs: unquote(rewritten_opts[:inputs]),
           outputs: unquote(rewritten_opts[:outputs]),
@@ -5179,8 +5230,8 @@ defmodule Runic do
           name: rule_name,
           arity: unquote(arity),
           workflow: unquote(workflow),
-          condition_hash: unquote(condition_hash),
-          reaction_hash: unquote(reaction_hash),
+          condition_hash: unquote(identity_ast(condition_hash)),
+          reaction_hash: unquote(identity_ast(reaction_hash)),
           hash: rule_hash,
           closure: closure,
           inputs: unquote(rewritten_opts[:inputs]),
@@ -5522,7 +5573,8 @@ defmodule Runic do
   defp workflow_of_rule({condition, reaction}, arity) do
     reaction_ast_hash = Components.fact_hash(reaction)
 
-    reaction = quote(do: Step.new(work: unquote(reaction), hash: unquote(reaction_ast_hash)))
+    reaction =
+      quote(do: Step.new(work: unquote(reaction), hash: unquote(identity_ast(reaction_ast_hash))))
 
     condition_ast_hash = Components.fact_hash(condition)
 
@@ -5531,7 +5583,7 @@ defmodule Runic do
         do:
           Condition.new(
             work: unquote(condition),
-            hash: unquote(condition_ast_hash),
+            hash: unquote(identity_ast(condition_ast_hash)),
             arity: unquote(arity)
           )
       )
@@ -5551,7 +5603,10 @@ defmodule Runic do
   defp workflow_of_rule({:fn, _, [{:->, _, [[], _rhs]}]} = expression, 0 = _arity) do
     reaction_ast_hash = Components.fact_hash(expression)
 
-    reaction = quote(do: Step.new(work: unquote(expression), hash: unquote(reaction_ast_hash)))
+    reaction =
+      quote(
+        do: Step.new(work: unquote(expression), hash: unquote(identity_ast(reaction_ast_hash)))
+      )
 
     workflow =
       quote do
@@ -5577,7 +5632,7 @@ defmodule Runic do
         do:
           Step.new(
             work: unquote(expression),
-            hash: unquote(reaction_ast_hash)
+            hash: unquote(identity_ast(reaction_ast_hash))
           )
       )
 
@@ -5600,7 +5655,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fun),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: unquote(arity)
         )
       end
@@ -5659,13 +5714,17 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fun),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: unquote(arity)
         )
       end
 
     reaction_ast_hash = Components.fact_hash(expression)
-    reaction = quote(do: Step.new(work: unquote(expression), hash: unquote(reaction_ast_hash)))
+
+    reaction =
+      quote(
+        do: Step.new(work: unquote(expression), hash: unquote(identity_ast(reaction_ast_hash)))
+      )
 
     workflow =
       quote do
@@ -5693,7 +5752,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(reaction),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
       end
@@ -5705,7 +5764,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: unquote(condition_arity),
           meta_refs: unquote(escaped_condition_meta_refs)
         )
@@ -5789,7 +5848,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(meta_reaction),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -5820,7 +5879,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(meta_reaction),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -5844,7 +5903,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fun),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: unquote(arity)
         )
       end
@@ -5881,7 +5940,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(meta_reaction),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -5918,7 +5977,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fun),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: unquote(arity)
         )
       end
@@ -5930,7 +5989,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(meta_reaction),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_meta_refs)
         )
       end
@@ -6552,7 +6611,7 @@ defmodule Runic do
       quote do
         Step.new(
           work: unquote(reaction_fn),
-          hash: unquote(reaction_ast_hash),
+          hash: unquote(identity_ast(reaction_ast_hash)),
           meta_refs: unquote(escaped_reaction_meta_refs)
         )
       end
@@ -6619,7 +6678,7 @@ defmodule Runic do
           quote do
             Condition.new(
               work: unquote(condition_fn),
-              hash: unquote(condition_ast_hash),
+              hash: unquote(identity_ast(condition_ast_hash)),
               arity: 1
             )
           end
@@ -6632,7 +6691,7 @@ defmodule Runic do
 
     conjunction =
       quote do
-        Conjunction.new(unquote(inline_hashes), unquote(escaped_refs))
+        Conjunction.new(unquote(identity_ast(inline_hashes)), unquote(escaped_refs))
       end
 
     workflow =
@@ -6661,12 +6720,12 @@ defmodule Runic do
 
     conjunction_hash =
       quote do
-        Conjunction.new(unquote(inline_hashes), unquote(escaped_refs)).hash
+        Conjunction.new(unquote(identity_ast(inline_hashes)), unquote(escaped_refs)).hash
       end
 
     rule_condition_refs =
       quote do
-        conj_hash = unquote(conjunction_hash)
+        conj_hash = unquote(identity_ast(conjunction_hash))
         Enum.map(unquote(escaped_refs), fn ref_name -> {ref_name, conj_hash} end)
       end
 
@@ -6749,7 +6808,10 @@ defmodule Runic do
 
     # Separate static and dynamic refs
     {static_refs, dynamic_refs} =
-      Enum.split_with(rule_condition_refs, fn {_name, target} -> is_integer(target) end)
+      Enum.split_with(rule_condition_refs, fn
+        {_name, %Runic.Identity{}} -> true
+        {_name, target} -> is_integer(target)
+      end)
 
     rule_condition_refs_ast =
       if Enum.empty?(dynamic_refs) do
@@ -6785,7 +6847,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fn),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: 1
         )
       end
@@ -6807,7 +6869,7 @@ defmodule Runic do
           quote do
             Condition.new(
               work: unquote(condition_fn),
-              hash: unquote(condition_ast_hash),
+              hash: unquote(identity_ast(condition_ast_hash)),
               arity: 1
             )
           end
@@ -6820,7 +6882,7 @@ defmodule Runic do
 
     conj_hash_ast =
       quote do
-        Conjunction.new(unquote(inline_hashes), unquote(escaped_refs)).hash
+        Conjunction.new(unquote(identity_ast(inline_hashes)), unquote(escaped_refs)).hash
       end
 
     {:and_branch, inline_conditions, condition_refs, conj_hash_ast}
@@ -6850,7 +6912,7 @@ defmodule Runic do
             escaped_refs = Macro.escape(condition_refs)
 
             quote do
-              conj = Conjunction.new(unquote(inline_hashes), unquote(escaped_refs))
+              conj = Conjunction.new(unquote(identity_ast(inline_hashes)), unquote(escaped_refs))
 
               wrk =
                 Enum.reduce(
@@ -6861,7 +6923,7 @@ defmodule Runic do
 
               branch_inline_conds =
                 Enum.filter(Multigraph.vertices(wrk.graph), fn
-                  %Condition{hash: h} -> h in unquote(inline_hashes)
+                  %Condition{hash: h} -> h in unquote(identity_ast(inline_hashes))
                   _ -> false
                 end)
 
@@ -6939,7 +7001,7 @@ defmodule Runic do
       quote do
         Condition.new(
           work: unquote(condition_fn),
-          hash: unquote(condition_ast_hash),
+          hash: unquote(identity_ast(condition_ast_hash)),
           arity: 1
         )
       end

--- a/lib/runic/runner/store.ex
+++ b/lib/runic/runner/store.ex
@@ -45,6 +45,8 @@ defmodule Runic.Runner.Store do
     after cursor instead of full replay).
   - **Fact storage** (`save_fact/3`, `load_fact/2`): Content-addressed fact
     value storage for hybrid rehydration without loading all values into memory.
+  - **Payload storage** (`save_payload/3`, `load_payload/2`): Immutable encoded
+    payload bytes keyed by a `:payload` `Runic.Identity`.
   """
 
   @type workflow_id :: term()
@@ -83,6 +85,11 @@ defmodule Runic.Runner.Store do
   @callback load_fact(fact_hash :: term(), state()) ::
               {:ok, term()} | {:error, :not_found | term()}
 
+  @callback save_payload(Runic.Identity.t(), encoded_payload :: binary(), state()) ::
+              :ok | {:error, term()}
+  @callback load_payload(Runic.Identity.t(), state()) ::
+              {:ok, binary()} | {:error, :not_found | term()}
+
   # Lifecycle (optional)
   @callback checkpoint(workflow_id(), log(), state()) :: :ok | {:error, term()}
   @callback delete(workflow_id(), state()) :: :ok | {:error, term()}
@@ -97,6 +104,8 @@ defmodule Runic.Runner.Store do
     load_snapshot: 2,
     save_fact: 3,
     load_fact: 2,
+    save_payload: 3,
+    load_payload: 2,
     checkpoint: 3,
     delete: 2,
     list: 1,

--- a/lib/runic/runner/store/ets.ex
+++ b/lib/runic/runner/store/ets.ex
@@ -117,6 +117,17 @@ defmodule Runic.Runner.Store.ETS do
     end
   end
 
+  @impl Runic.Runner.Store
+  def save_payload(%Runic.Identity{domain: :payload} = digest, encoded_payload, state)
+      when is_binary(encoded_payload) do
+    save_fact(digest, encoded_payload, state)
+  end
+
+  @impl Runic.Runner.Store
+  def load_payload(%Runic.Identity{domain: :payload} = digest, state) do
+    load_fact(digest, state)
+  end
+
   # --- Lifecycle ---
 
   @impl Runic.Runner.Store

--- a/lib/runic/runner/store/mnesia.ex
+++ b/lib/runic/runner/store/mnesia.ex
@@ -176,6 +176,17 @@ defmodule Runic.Runner.Store.Mnesia do
     end
   end
 
+  @impl Runic.Runner.Store
+  def save_payload(%Runic.Identity{domain: :payload} = digest, encoded_payload, state)
+      when is_binary(encoded_payload) do
+    save_fact(digest, encoded_payload, state)
+  end
+
+  @impl Runic.Runner.Store
+  def load_payload(%Runic.Identity{domain: :payload} = digest, state) do
+    load_fact(digest, state)
+  end
+
   # --- Lifecycle ---
 
   @impl Runic.Runner.Store

--- a/lib/runic/runner/worker.ex
+++ b/lib/runic/runner/worker.ex
@@ -1197,6 +1197,17 @@ defmodule Runic.Runner.Worker do
         _ -> :ok
       end)
     end
+
+    if function_exported?(store_mod, :save_payload, 3) do
+      Enum.each(events, fn
+        %FactProduced{payload_digest: %Runic.Identity{} = digest, value: value} ->
+          encoded_payload = :erlang.term_to_binary(value, [:deterministic])
+          store_mod.save_payload(digest, encoded_payload, store_state)
+
+        _other ->
+          :ok
+      end)
+    end
   end
 
   defp strip_fact_values(events) do

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -1775,7 +1775,9 @@ defmodule Runic.Workflow do
         # New format: use closure if available
         not is_nil(closure) ->
           {comp, _} = Closure.eval(closure)
-          comp
+          # The recorded closure is the authored definition; evaluation may
+          # reconstruct it with different binding metadata or macro context.
+          Map.replace(comp, :closure, closure)
 
         # Old format: source + bindings with __caller_context__
         not is_nil(source) ->

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -263,7 +263,7 @@ defmodule Runic.Workflow do
   @type t() :: %__MODULE__{
           name: String.t(),
           graph: Multigraph.t(),
-          hash: binary(),
+          hash: Runic.Identity.t() | integer() | binary() | nil,
           # name -> component hash
           components: map(),
           # node_hash -> list(hook_functions)
@@ -753,6 +753,10 @@ defmodule Runic.Workflow do
         parent_step = get_component!(workflow, component_name)
         do_add_component(workflow, component, parent_step, opts)
 
+      %Runic.Identity{} = hash ->
+        parent_step = get_by_hash(workflow, hash)
+        do_add_component(workflow, component, parent_step, opts)
+
       hash when is_integer(hash) ->
         parent_step = get_by_hash(workflow, hash)
         do_add_component(workflow, component, parent_step, opts)
@@ -862,6 +866,13 @@ defmodule Runic.Workflow do
       source_outputs: source_outputs,
       source_port_index: source_port_index
     }
+  end
+
+  defp resolve_component_ref!(workflow, %Runic.Identity{} = identity) do
+    case get_by_hash(workflow, identity) do
+      nil -> raise KeyError, message: "No component found with identity #{inspect(identity)}"
+      component -> component
+    end
   end
 
   defp resolve_component_ref!(_workflow, %{__struct__: _} = component), do: component
@@ -1443,7 +1454,17 @@ defmodule Runic.Workflow do
   end
 
   def apply_event(%__MODULE__{} = wf, %FactProduced{} = e) do
-    fact = Fact.new(hash: e.hash, value: e.value, ancestry: e.ancestry, meta: e.meta)
+    fact =
+      Fact.new(
+        hash: e.hash,
+        content_digest: e.content_digest,
+        payload_digest: e.payload_digest,
+        value: e.value,
+        ancestry: e.ancestry,
+        causal_ancestry: e.causal_ancestry,
+        meta: e.meta
+      )
+
     wf = log_fact(wf, fact)
 
     case e.ancestry do
@@ -1564,7 +1585,14 @@ defmodule Runic.Workflow do
 
   def apply_event(%__MODULE__{} = wf, %FanOutFactEmitted{} = e) do
     fact =
-      Fact.new(hash: e.emitted_fact_hash, value: e.emitted_value, ancestry: e.emitted_ancestry)
+      Fact.new(
+        hash: e.emitted_fact_hash,
+        content_digest: e.emitted_content_digest,
+        payload_digest: e.emitted_payload_digest,
+        value: e.emitted_value,
+        ancestry: e.emitted_ancestry,
+        causal_ancestry: e.emitted_causal_ancestry
+      )
 
     fan_out = Map.get(wf.graph.vertices, e.fan_out_hash)
 
@@ -1608,7 +1636,15 @@ defmodule Runic.Workflow do
   # Lean replay: creates FactRef instead of Fact when value was stripped.
   # Falls back to full Fact for legacy events that still carry values (migration).
   defp apply_event_lean(%__MODULE__{} = wf, %FactProduced{value: nil} = e) do
-    ref = %FactRef{hash: e.hash, ancestry: e.ancestry}
+    ref = %FactRef{
+      id: if(is_struct(e.hash, Runic.Identity), do: e.hash),
+      content_digest: e.content_digest,
+      payload_digest: e.payload_digest,
+      hash: e.hash,
+      ancestry: e.ancestry,
+      causal_ancestry: e.causal_ancestry
+    }
+
     wf = log_fact(wf, ref)
 
     case e.ancestry do
@@ -2275,6 +2311,10 @@ defmodule Runic.Workflow do
     get_by_hash(workflow, hash)
   end
 
+  defp resolve_component_to_node(%__MODULE__{} = workflow, %Runic.Identity{} = identity) do
+    get_by_hash(workflow, identity)
+  end
+
   @doc """
   Attaches a hook function to be run before a given component step.
 
@@ -2516,6 +2556,10 @@ defmodule Runic.Workflow do
 
   defp get_by_hash(%__MODULE__{graph: g}, hash) when is_integer(hash) do
     Map.get(g.vertices, hash)
+  end
+
+  defp get_by_hash(%__MODULE__{graph: g}, %Runic.Identity{} = identity) do
+    Map.get(g.vertices, identity)
   end
 
   defp get_by_hash(_, _hash) do
@@ -4501,7 +4545,7 @@ defmodule Runic.Workflow do
         %{hash: hash} ->
           Map.get(graph.vertices, hash, edge.v2)
 
-        hash when is_integer(hash) ->
+        hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
           Map.get(graph.vertices, hash)
 
         _ ->
@@ -4537,7 +4581,7 @@ defmodule Runic.Workflow do
         %{hash: hash} ->
           Map.get(graph.vertices, hash, edge.v1)
 
-        hash when is_integer(hash) ->
+        hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
           Map.get(graph.vertices, hash)
 
         _ ->

--- a/lib/workflow/causal_context.ex
+++ b/lib/workflow/causal_context.ex
@@ -28,7 +28,7 @@ defmodule Runic.Workflow.CausalContext do
   alias Runic.Workflow.Fact
 
   @type t :: %__MODULE__{
-          node_hash: integer() | nil,
+          node_hash: term() | nil,
           input_fact: Fact.t() | nil,
           ancestry_depth: non_neg_integer(),
           hooks: {list(), list()},
@@ -70,7 +70,7 @@ defmodule Runic.Workflow.CausalContext do
   @doc """
   Builds a basic context with node hash, input fact, and ancestry depth.
   """
-  @spec basic(integer(), Fact.t(), non_neg_integer()) :: t()
+  @spec basic(term(), Fact.t(), non_neg_integer()) :: t()
   def basic(node_hash, input_fact, ancestry_depth) do
     %__MODULE__{
       node_hash: node_hash,

--- a/lib/workflow/compilation_utils.ex
+++ b/lib/workflow/compilation_utils.ex
@@ -122,8 +122,8 @@ defmodule Runic.Workflow.CompilationUtils do
     join =
       quote do
         %Join{
-          hash: unquote(join_hash),
-          joins: unquote(parent_hashes)
+          hash: unquote(Macro.escape(join_hash)),
+          joins: unquote(Macro.escape(parent_hashes))
         }
       end
 
@@ -143,7 +143,7 @@ defmodule Runic.Workflow.CompilationUtils do
 
     quote do
       unquote(wrk_acc)
-      |> Workflow.add(unquote(dependent_pipeline_workflow), to: unquote(join_hash))
+      |> Workflow.add(unquote(dependent_pipeline_workflow), to: unquote(Macro.escape(join_hash)))
     end
   end
 
@@ -199,7 +199,7 @@ defmodule Runic.Workflow.CompilationUtils do
     step_ast_hash = Components.fact_hash(expression)
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash))
+      Runic.step(work: unquote(expression), hash: unquote(Macro.escape(step_ast_hash)))
     end
   end
 
@@ -207,7 +207,7 @@ defmodule Runic.Workflow.CompilationUtils do
     step_ast_hash = Components.fact_hash(expression)
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash))
+      Runic.step(work: unquote(expression), hash: unquote(Macro.escape(step_ast_hash)))
     end
   end
 
@@ -217,7 +217,11 @@ defmodule Runic.Workflow.CompilationUtils do
     name = rest[:name]
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash), name: unquote(name))
+      Runic.step(
+        work: unquote(expression),
+        hash: unquote(Macro.escape(step_ast_hash)),
+        name: unquote(name)
+      )
     end
   end
 
@@ -225,7 +229,7 @@ defmodule Runic.Workflow.CompilationUtils do
     step_ast_hash = Components.fact_hash(expression)
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash))
+      Runic.step(work: unquote(expression), hash: unquote(Macro.escape(step_ast_hash)))
     end
   end
 
@@ -235,7 +239,11 @@ defmodule Runic.Workflow.CompilationUtils do
     name = rest[:name]
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash), name: unquote(name))
+      Runic.step(
+        work: unquote(expression),
+        hash: unquote(Macro.escape(step_ast_hash)),
+        name: unquote(name)
+      )
     end
   end
 
@@ -243,7 +251,7 @@ defmodule Runic.Workflow.CompilationUtils do
     step_ast_hash = Components.fact_hash(expression)
 
     quote do
-      Runic.step(work: unquote(expression), hash: unquote(step_ast_hash))
+      Runic.step(work: unquote(expression), hash: unquote(Macro.escape(step_ast_hash)))
     end
   end
 end

--- a/lib/workflow/component.ex
+++ b/lib/workflow/component.ex
@@ -778,7 +778,7 @@ defimpl Runic.Component, for: Runic.Workflow.Rule do
         name when is_atom(name) ->
           Workflow.get_component(wrk, name)
 
-        hash when is_integer(hash) ->
+        hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
           Map.get(wrk.graph.vertices, hash)
 
         {_parent, _subcomponent} = tuple_ref ->
@@ -1558,9 +1558,14 @@ defimpl Runic.Component, for: Runic.Workflow.Accumulator do
 
         target_component =
           case target do
-            name when is_atom(name) -> Workflow.get_component(wrk, name)
-            hash when is_integer(hash) -> Map.get(wrk.graph.vertices, hash)
-            _ -> nil
+            name when is_atom(name) ->
+              Workflow.get_component(wrk, name)
+
+            hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
+              Map.get(wrk.graph.vertices, hash)
+
+            _ ->
+              nil
           end
 
         if target_component do
@@ -1680,7 +1685,7 @@ defimpl Runic.Component, for: Runic.Workflow.Condition do
           name when is_atom(name) ->
             Workflow.get_component(wrk, name)
 
-          hash when is_integer(hash) ->
+          hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
             Map.get(wrk.graph.vertices, hash)
 
           {_parent, _subcomponent} = tuple_ref ->
@@ -1844,7 +1849,7 @@ defimpl Runic.Component, for: Runic.Workflow do
   def hash(%Workflow{hash: hash}) when not is_nil(hash), do: hash
 
   def hash(%Workflow{} = workflow) do
-    Runic.Workflow.Components.fact_hash(workflow)
+    Runic.Identity.digest(:workflow_artifact, artifact_document(workflow))
   end
 
   def inputs(%Workflow{input_ports: nil}), do: []
@@ -1852,6 +1857,55 @@ defimpl Runic.Component, for: Runic.Workflow do
 
   def outputs(%Workflow{output_ports: nil}), do: []
   def outputs(%Workflow{output_ports: ports}), do: ports
+
+  defp artifact_document(workflow) do
+    nodes =
+      workflow.graph
+      |> Multigraph.vertices()
+      |> Enum.reject(
+        &(is_struct(&1, Runic.Workflow.Fact) or is_struct(&1, Runic.Workflow.FactRef))
+      )
+      |> Enum.map(fn node ->
+        %{
+          id: Runic.Workflow.Components.vertex_id_of(node),
+          kind: node.__struct__,
+          name: Map.get(node, :name)
+        }
+      end)
+      |> Enum.sort_by(&identity_sort_key(&1.id))
+
+    node_ids = MapSet.new(nodes, & &1.id)
+
+    connections =
+      workflow.graph
+      |> Multigraph.edges()
+      |> Enum.filter(fn edge ->
+        MapSet.member?(node_ids, Runic.Workflow.Components.vertex_id_of(edge.v1)) and
+          MapSet.member?(node_ids, Runic.Workflow.Components.vertex_id_of(edge.v2))
+      end)
+      |> Enum.map(fn edge ->
+        %{
+          source: Runic.Workflow.Components.vertex_id_of(edge.v1),
+          target: Runic.Workflow.Components.vertex_id_of(edge.v2),
+          label: edge.label,
+          weight: edge.weight
+        }
+      end)
+      |> Enum.sort_by(fn edge ->
+        {identity_sort_key(edge.source), identity_sort_key(edge.target), edge.label, edge.weight}
+      end)
+
+    %{
+      kind: :workflow_artifact,
+      version: 1,
+      boundary: %{inputs: workflow.input_ports, outputs: workflow.output_ports},
+      nodes: nodes,
+      connections: connections
+    }
+  end
+
+  defp identity_sort_key(%Runic.Identity{} = identity), do: Runic.Identity.to_binary(identity)
+  defp identity_sort_key(other), do: :erlang.term_to_binary(other, [:deterministic])
 end
 
 defimpl Runic.Component, for: Tuple do
@@ -1875,6 +1929,15 @@ defimpl Runic.Component, for: Tuple do
   def outputs(_tuple), do: []
 
   def hash(pipeline) do
-    Runic.Workflow.Components.fact_hash(pipeline)
+    Runic.Identity.digest(:workflow_artifact, pipeline_document(pipeline))
   end
+
+  defp pipeline_document({parent, children}) when is_list(children) do
+    %{
+      parent: Runic.Component.hash(parent),
+      children: Enum.map(children, &pipeline_document/1)
+    }
+  end
+
+  defp pipeline_document(component), do: %{component: Runic.Component.hash(component)}
 end

--- a/lib/workflow/component.ex
+++ b/lib/workflow/component.ex
@@ -1869,7 +1869,8 @@ defimpl Runic.Component, for: Runic.Workflow do
         %{
           id: Runic.Workflow.Components.vertex_id_of(node),
           kind: node.__struct__,
-          name: Map.get(node, :name)
+          name: Map.get(node, :name),
+          definition: node_definition(node)
         }
       end)
       |> Enum.sort_by(&identity_sort_key(&1.id))
@@ -1902,6 +1903,16 @@ defimpl Runic.Component, for: Runic.Workflow do
       nodes: nodes,
       connections: connections
     }
+  end
+
+  defp node_definition(node) do
+    case Runic.Identity.Projectable.impl_for(node) do
+      Runic.Identity.Projectable.Any ->
+        Map.take(node, [:hash, :inputs, :outputs, :meta_refs, :mergeable])
+
+      implementation ->
+        implementation.identity_document(node)
+    end
   end
 
   defp identity_sort_key(%Runic.Identity{} = identity), do: Runic.Identity.to_binary(identity)

--- a/lib/workflow/component_removed.ex
+++ b/lib/workflow/component_removed.ex
@@ -4,7 +4,7 @@ defmodule Runic.Workflow.ComponentRemoved do
 
   @type t :: %__MODULE__{
           name: atom() | String.t(),
-          hash: integer() | nil
+          hash: Runic.Identity.t() | integer() | binary() | nil
         }
 
   defstruct [:name, :hash]

--- a/lib/workflow/components.ex
+++ b/lib/workflow/components.ex
@@ -1,9 +1,21 @@
 defmodule Runic.Workflow.Components do
   # common functions across workflow components
-  @doc false
+  @moduledoc false
   @max_phash 4_294_967_296
+  @hash_scheme :phash2_64_v1
 
-  def fact_hash(value), do: :erlang.phash2(value, @max_phash)
+  @doc false
+  @spec hash_scheme() :: :phash2_64_v1
+  def hash_scheme, do: @hash_scheme
+
+  @doc false
+  @spec fact_hash(term()) :: non_neg_integer()
+  def fact_hash(term) do
+    high = :erlang.phash2(term, @max_phash)
+    low = :erlang.phash2({@hash_scheme, :secondary, term}, @max_phash)
+
+    high * @max_phash + low
+  end
 
   def vertex_id_of(%Runic.Workflow.FactRef{hash: hash}), do: hash
   def vertex_id_of(%{hash: hash}), do: hash

--- a/lib/workflow/components.ex
+++ b/lib/workflow/components.ex
@@ -1,30 +1,37 @@
 defmodule Runic.Workflow.Components do
   # common functions across workflow components
   @moduledoc false
-  @max_phash 4_294_967_296
-  @hash_scheme :phash2_64_v1
+
+  alias Runic.Identity
+  alias Runic.Workflow.Root
+
+  @hash_scheme :sha256_v1
 
   @doc false
-  @spec hash_scheme() :: :phash2_64_v1
+  @spec hash_scheme() :: :sha256_v1
   def hash_scheme, do: @hash_scheme
 
   @doc false
-  @spec fact_hash(term()) :: non_neg_integer()
-  def fact_hash(term) do
-    high = :erlang.phash2(term, @max_phash)
-    low = :erlang.phash2({@hash_scheme, :secondary, term}, @max_phash)
+  @spec fact_hash(term()) :: Identity.t()
+  def fact_hash(term), do: identity(:component_definition, term)
 
-    high * @max_phash + low
-  end
+  @doc false
+  @spec identity(Identity.domain(), term()) :: Identity.t()
+  def identity(domain, identity_document), do: Identity.digest(domain, identity_document)
 
   def vertex_id_of(%Runic.Workflow.FactRef{hash: hash}), do: hash
   def vertex_id_of(%{hash: hash}), do: hash
+  def vertex_id_of(%Identity{} = identity), do: identity
+  def vertex_id_of(%Root{}), do: Identity.derive(:node_occurrence, [:workflow_root])
   def vertex_id_of(hash) when is_integer(hash), do: hash
-  def vertex_id_of(anything_otherwise), do: fact_hash(anything_otherwise)
+  def vertex_id_of(anything_otherwise), do: Identity.digest(:node_occurrence, anything_otherwise)
 
   def memory_vertex_id(%{hash: hash}), do: hash
+  def memory_vertex_id(%Identity{} = identity), do: identity
   def memory_vertex_id(hash) when is_integer(hash), do: hash
-  def memory_vertex_id(anything_otherwise), do: fact_hash(anything_otherwise)
+
+  def memory_vertex_id(anything_otherwise),
+    do: Identity.digest(:fact_occurrence, anything_otherwise)
 
   def work_hash({m, f}),
     do: work_hash({m, f, 1})

--- a/lib/workflow/condition.ex
+++ b/lib/workflow/condition.ex
@@ -34,16 +34,16 @@ defmodule Runic.Workflow.Condition do
 
   @type meta_ref :: %{
           kind: atom(),
-          target: atom() | integer() | {atom(), atom()},
+          target: atom() | Runic.Identity.t() | integer() | {atom(), atom()},
           field_path: list(atom()),
           context_key: atom()
         }
 
   @type t :: %__MODULE__{
           name: String.t() | atom() | nil,
-          hash: integer() | nil,
+          hash: Runic.Identity.t() | integer() | binary() | nil,
           work: function(),
-          work_hash: integer() | nil,
+          work_hash: Runic.Identity.t() | integer() | binary() | nil,
           closure: Closure.t() | nil,
           arity: non_neg_integer(),
           meta_refs: list(meta_ref())

--- a/lib/workflow/conjunction.ex
+++ b/lib/workflow/conjunction.ex
@@ -20,7 +20,7 @@ defmodule Runic.Workflow.Conjunction do
     condition_hashes = conditions |> MapSet.new(& &1.hash)
 
     %__MODULE__{
-      hash: condition_hashes |> Components.fact_hash(),
+      hash: condition_hashes |> Enum.sort() |> Components.fact_hash(),
       condition_hashes: condition_hashes
     }
   end

--- a/lib/workflow/connection.ex
+++ b/lib/workflow/connection.ex
@@ -53,7 +53,7 @@ defmodule Runic.Workflow.Connection do
   @type component_ref :: atom() | String.t() | non_neg_integer() | {atom() | String.t(), atom()}
   @type port_name :: atom()
   @type path_segment :: atom() | String.t() | non_neg_integer()
-  @type connection_id :: atom() | String.t() | non_neg_integer()
+  @type connection_id :: atom() | String.t() | non_neg_integer() | Runic.Identity.t()
 
   @type t :: %__MODULE__{
           id: connection_id(),
@@ -102,7 +102,10 @@ defmodule Runic.Workflow.Connection do
 
     id =
       Map.get(spec, :id) ||
-        Components.fact_hash({source, source_port, target, target_port, selector, target_path})
+        Components.identity(
+          :connection_definition,
+          {source, source_port, target, target_port, selector, target_path}
+        )
 
     validate_connection!(%__MODULE__{
       id: id,
@@ -164,9 +167,10 @@ defmodule Runic.Workflow.Connection do
     normalize_path!(connection.target_path, :target_path)
 
     unless is_atom(connection.id) or is_binary(connection.id) or
-             (is_integer(connection.id) and connection.id >= 0) do
+             (is_integer(connection.id) and connection.id >= 0) or
+             is_struct(connection.id, Runic.Identity) do
       raise ArgumentError,
-            "connection id must be an atom, string, or non-negative integer, got: #{inspect(connection.id)}"
+            "connection id must be an identity, atom, string, or non-negative integer, got: #{inspect(connection.id)}"
     end
 
     connection

--- a/lib/workflow/events/fact_produced.ex
+++ b/lib/workflow/events/fact_produced.ex
@@ -11,12 +11,42 @@ defmodule Runic.Workflow.Events.FactProduced do
 
   @type t :: %__MODULE__{
           hash: term(),
+          content_digest: Runic.Identity.t() | nil,
+          payload_digest: Runic.Identity.t() | nil,
           value: term(),
           ancestry: {term(), term()} | nil,
+          causal_ancestry: Runic.Workflow.FactAncestry.t() | nil,
           producer_label: atom(),
           weight: non_neg_integer(),
           meta: map()
         }
 
-  defstruct [:hash, :value, :ancestry, :producer_label, :weight, meta: %{}]
+  defstruct [
+    :hash,
+    :content_digest,
+    :payload_digest,
+    :value,
+    :ancestry,
+    :causal_ancestry,
+    :producer_label,
+    :weight,
+    meta: %{}
+  ]
+
+  @doc "Builds a versioned identity-bearing event from a Fact."
+  @spec new(Runic.Workflow.Fact.t(), keyword()) :: t()
+  def new(%Runic.Workflow.Fact{} = fact, attrs) when is_list(attrs) do
+    struct!(
+      __MODULE__,
+      [
+        hash: fact.hash,
+        content_digest: fact.content_digest,
+        payload_digest: fact.payload_digest,
+        value: fact.value,
+        ancestry: fact.ancestry,
+        causal_ancestry: fact.causal_ancestry,
+        meta: fact.meta
+      ] ++ attrs
+    )
+  end
 end

--- a/lib/workflow/events/fan_out_fact_emitted.ex
+++ b/lib/workflow/events/fan_out_fact_emitted.ex
@@ -11,8 +11,11 @@ defmodule Runic.Workflow.Events.FanOutFactEmitted do
           fan_out_hash: term(),
           source_fact_hash: term(),
           emitted_fact_hash: term(),
+          emitted_content_digest: Runic.Identity.t() | nil,
+          emitted_payload_digest: Runic.Identity.t() | nil,
           emitted_value: term(),
           emitted_ancestry: {term(), term()} | nil,
+          emitted_causal_ancestry: Runic.Workflow.FactAncestry.t() | nil,
           weight: non_neg_integer()
         }
 
@@ -20,8 +23,11 @@ defmodule Runic.Workflow.Events.FanOutFactEmitted do
     :fan_out_hash,
     :source_fact_hash,
     :emitted_fact_hash,
+    :emitted_content_digest,
+    :emitted_payload_digest,
     :emitted_value,
     :emitted_ancestry,
+    :emitted_causal_ancestry,
     :weight
   ]
 end

--- a/lib/workflow/fact.ex
+++ b/lib/workflow/fact.ex
@@ -1,26 +1,84 @@
 defmodule Runic.Workflow.Fact do
+  alias Runic.Identity
   alias Runic.Workflow.Components
-  defstruct [:hash, :value, :ancestry, meta: %{}]
+  alias Runic.Workflow.FactAncestry
 
-  @type hash() :: integer() | binary()
+  defstruct [
+    :id,
+    :content_digest,
+    :payload_digest,
+    :hash,
+    :value,
+    :ancestry,
+    :causal_ancestry,
+    meta: %{}
+  ]
+
+  @type hash() :: Identity.t() | integer() | binary()
 
   @type t() :: %__MODULE__{
+          id: Identity.t() | nil,
+          content_digest: Identity.t() | nil,
+          payload_digest: Identity.t() | nil,
           value: term(),
           hash: hash(),
-          ancestry: {hash(), hash()},
+          ancestry: {hash(), hash()} | nil,
+          causal_ancestry: FactAncestry.t() | nil,
           meta: map()
         }
 
   def new(params) do
     struct!(__MODULE__, params)
-    |> maybe_set_hash()
+    |> put_identities()
   end
 
-  defp maybe_set_hash(%__MODULE__{value: value, hash: nil} = fact) do
-    %__MODULE__{fact | hash: Components.fact_hash({value, fact.ancestry})}
+  defp put_identities(%__MODULE__{} = fact) do
+    causal_ancestry = fact.causal_ancestry || FactAncestry.from_legacy(fact.ancestry)
+
+    payload_digest =
+      fact.payload_digest ||
+        Components.identity(:payload, %{
+          codec: :runic_canonical,
+          schema_version: 1,
+          value: fact.value
+        })
+
+    content_digest =
+      fact.content_digest ||
+        Components.identity(:fact_content, %{
+          producer_node_id: causal_ancestry.producer_node_id,
+          parent_fact_id: causal_ancestry.parent_fact_id,
+          output_port: causal_ancestry.output_port,
+          output_index: causal_ancestry.output_index,
+          payload_digest: payload_digest
+        })
+
+    {id, hash} = occurrence_identity(fact.hash, causal_ancestry, content_digest)
+
+    %__MODULE__{
+      fact
+      | id: id,
+        hash: hash,
+        payload_digest: payload_digest,
+        content_digest: content_digest,
+        causal_ancestry: causal_ancestry
+    }
   end
 
-  defp maybe_set_hash(%__MODULE__{hash: hash} = fact)
-       when not is_nil(hash),
-       do: fact
+  defp occurrence_identity(nil, causal_ancestry, content_digest) do
+    id =
+      Components.identity(:fact_occurrence, %{
+        activation_id: causal_ancestry.activation_id,
+        output_port: causal_ancestry.output_port,
+        output_index: causal_ancestry.output_index,
+        content_digest: content_digest
+      })
+
+    {id, id}
+  end
+
+  defp occurrence_identity(%Identity{domain: :fact_occurrence} = id, _ancestry, _content),
+    do: {id, id}
+
+  defp occurrence_identity(legacy_hash, _ancestry, _content), do: {nil, legacy_hash}
 end

--- a/lib/workflow/fact.ex
+++ b/lib/workflow/fact.ex
@@ -27,6 +27,14 @@ defmodule Runic.Workflow.Fact do
           meta: map()
         }
 
+  @doc """
+  Constructs a Fact and its payload, content, and occurrence identities.
+
+  Supply a `:fact_occurrence` Identity in `:id` to distinguish equal inputs.
+  The compatibility `:hash` field mirrors that ID; supplying both fields with
+  different identities raises. Legacy integer or binary hashes remain accepted
+  when no `:id` is supplied.
+  """
   def new(params) do
     struct!(__MODULE__, params)
     |> put_identities()
@@ -53,7 +61,7 @@ defmodule Runic.Workflow.Fact do
           payload_digest: payload_digest
         })
 
-    {id, hash} = occurrence_identity(fact.hash, causal_ancestry, content_digest)
+    {id, hash} = occurrence_identity(supplied_identity!(fact), causal_ancestry, content_digest)
 
     %__MODULE__{
       fact
@@ -63,6 +71,31 @@ defmodule Runic.Workflow.Fact do
         content_digest: content_digest,
         causal_ancestry: causal_ancestry
     }
+  end
+
+  defp supplied_identity!(%__MODULE__{id: nil, hash: hash}), do: hash
+
+  defp supplied_identity!(%__MODULE__{id: id, hash: hash}) when is_nil(hash) or hash == id do
+    validate_occurrence_id!(id)
+  end
+
+  defp supplied_identity!(%__MODULE__{}) do
+    raise ArgumentError, "Fact id and hash must identify the same occurrence"
+  end
+
+  defp validate_occurrence_id!(
+         %Identity{
+           scheme: :sha256,
+           version: 1,
+           domain: :fact_occurrence,
+           digest: digest
+         } = id
+       )
+       when is_binary(digest) and byte_size(digest) == 32,
+       do: id
+
+  defp validate_occurrence_id!(id) do
+    raise ArgumentError, "expected a valid Fact occurrence identity, got: #{inspect(id)}"
   end
 
   defp occurrence_identity(nil, causal_ancestry, content_digest) do
@@ -77,8 +110,10 @@ defmodule Runic.Workflow.Fact do
     {id, id}
   end
 
-  defp occurrence_identity(%Identity{domain: :fact_occurrence} = id, _ancestry, _content),
-    do: {id, id}
+  defp occurrence_identity(%Identity{} = id, _ancestry, _content) do
+    id = validate_occurrence_id!(id)
+    {id, id}
+  end
 
   defp occurrence_identity(legacy_hash, _ancestry, _content), do: {nil, legacy_hash}
 end

--- a/lib/workflow/fact_ancestry.ex
+++ b/lib/workflow/fact_ancestry.ex
@@ -1,0 +1,65 @@
+defmodule Runic.Workflow.FactAncestry do
+  @moduledoc """
+  Explicit causal coordinates for a Fact occurrence.
+
+  The legacy `{producer_hash, parent_fact_hash}` tuple remains available on
+  `Runic.Workflow.Fact` during the alpha migration. This struct carries the
+  additional activation and output coordinates needed to distinguish equal
+  payloads produced at different positions.
+  """
+
+  alias Runic.Identity
+
+  @type t :: %__MODULE__{
+          producer_node_id: term() | nil,
+          parent_fact_id: term() | nil,
+          activation_id: Identity.t() | nil,
+          output_port: atom(),
+          output_index: non_neg_integer()
+        }
+
+  defstruct [
+    :producer_node_id,
+    :parent_fact_id,
+    :activation_id,
+    output_port: :out,
+    output_index: 0
+  ]
+
+  @doc false
+  def from_legacy(ancestry, opts \\ [])
+
+  def from_legacy(nil, opts) do
+    new(nil, nil, opts)
+  end
+
+  def from_legacy({producer_node_id, parent_fact_id}, opts) do
+    new(producer_node_id, parent_fact_id, opts)
+  end
+
+  @doc false
+  def to_document(%__MODULE__{} = ancestry) do
+    %{
+      producer_node_id: ancestry.producer_node_id,
+      parent_fact_id: ancestry.parent_fact_id,
+      activation_id: ancestry.activation_id,
+      output_port: ancestry.output_port,
+      output_index: ancestry.output_index
+    }
+  end
+
+  defp new(producer_node_id, parent_fact_id, opts) do
+    activation_id =
+      Keyword.get_lazy(opts, :activation_id, fn ->
+        Identity.derive(:activation, [:local, parent_fact_id, producer_node_id])
+      end)
+
+    %__MODULE__{
+      producer_node_id: producer_node_id,
+      parent_fact_id: parent_fact_id,
+      activation_id: activation_id,
+      output_port: Keyword.get(opts, :output_port, :out),
+      output_index: Keyword.get(opts, :output_index, 0)
+    }
+  end
+end

--- a/lib/workflow/fact_ref.ex
+++ b/lib/workflow/fact_ref.ex
@@ -7,9 +7,13 @@ defmodule Runic.Workflow.FactRef do
   """
 
   @type t :: %__MODULE__{
+          id: Runic.Identity.t() | nil,
+          content_digest: Runic.Identity.t() | nil,
+          payload_digest: Runic.Identity.t() | nil,
           hash: Runic.Workflow.Fact.hash(),
-          ancestry: {Runic.Workflow.Fact.hash(), Runic.Workflow.Fact.hash()} | nil
+          ancestry: {Runic.Workflow.Fact.hash(), Runic.Workflow.Fact.hash()} | nil,
+          causal_ancestry: Runic.Workflow.FactAncestry.t() | nil
         }
 
-  defstruct [:hash, :ancestry]
+  defstruct [:id, :content_digest, :payload_digest, :hash, :ancestry, :causal_ancestry]
 end

--- a/lib/workflow/fact_resolver.ex
+++ b/lib/workflow/fact_resolver.ex
@@ -7,6 +7,7 @@ defmodule Runic.Workflow.FactResolver do
   """
 
   alias Runic.Workflow.{Fact, FactRef}
+  alias Runic.Identity
 
   defstruct [:store, cache: %{}]
 
@@ -31,18 +32,18 @@ defmodule Runic.Workflow.FactResolver do
   @spec resolve(Fact.t() | FactRef.t(), t()) :: {:ok, Fact.t()} | {:error, term()}
   def resolve(%Fact{value: v} = fact, _resolver) when not is_nil(v), do: {:ok, fact}
 
-  def resolve(%FactRef{hash: h, ancestry: a}, %__MODULE__{} = resolver) do
+  def resolve(%FactRef{hash: h} = ref, %__MODULE__{} = resolver) do
     case Map.get(resolver.cache, h) do
       nil ->
         {mod, st} = resolver.store
 
         case mod.load_fact(h, st) do
-          {:ok, value} -> {:ok, %Fact{hash: h, ancestry: a, value: value}}
+          {:ok, value} -> resolve_value(ref, value)
           {:error, _} = err -> err
         end
 
       value ->
-        {:ok, %Fact{hash: h, ancestry: a, value: value}}
+        resolve_value(ref, value)
     end
   end
 
@@ -77,4 +78,27 @@ defmodule Runic.Workflow.FactResolver do
 
     %{resolver | cache: loaded}
   end
+
+  defp resolved_fact(%FactRef{} = ref, value) do
+    %Fact{
+      id: ref.id,
+      content_digest: ref.content_digest,
+      payload_digest: ref.payload_digest,
+      hash: ref.hash,
+      ancestry: ref.ancestry,
+      causal_ancestry: ref.causal_ancestry,
+      value: value
+    }
+  end
+
+  defp resolve_value(%FactRef{payload_digest: %Identity{} = digest} = ref, value) do
+    payload_document = %{codec: :runic_canonical, schema_version: 1, value: value}
+
+    case Identity.verify(digest, payload_document) do
+      :ok -> {:ok, resolved_fact(ref, value)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp resolve_value(%FactRef{} = ref, value), do: {:ok, resolved_fact(ref, value)}
 end

--- a/lib/workflow/facts.ex
+++ b/lib/workflow/facts.ex
@@ -25,5 +25,14 @@ defmodule Runic.Workflow.Facts do
 
   @doc "Converts a Fact to a FactRef, discarding the value."
   @spec to_ref(Fact.t()) :: FactRef.t()
-  def to_ref(%Fact{hash: h, ancestry: a}), do: %FactRef{hash: h, ancestry: a}
+  def to_ref(%Fact{} = fact) do
+    %FactRef{
+      id: fact.id,
+      content_digest: fact.content_digest,
+      payload_digest: fact.payload_digest,
+      hash: fact.hash,
+      ancestry: fact.ancestry,
+      causal_ancestry: fact.causal_ancestry
+    }
+  end
 end

--- a/lib/workflow/hook_event.ex
+++ b/lib/workflow/hook_event.ex
@@ -34,7 +34,7 @@ defmodule Runic.Workflow.HookEvent do
   @type t :: %__MODULE__{
           timing: timing(),
           node: struct(),
-          node_hash: integer(),
+          node_hash: term(),
           input_fact: Runic.Workflow.Fact.t(),
           result: term() | nil
         }

--- a/lib/workflow/identity_conflict_error.ex
+++ b/lib/workflow/identity_conflict_error.ex
@@ -1,0 +1,25 @@
+defmodule Runic.Workflow.IdentityConflictError do
+  @moduledoc """
+  Raised when distinct workflow vertices claim the same identity.
+
+  Runic treats an identity match as an optimization only when the available
+  identity evidence is equivalent. A conflict is raised before graph mutation
+  so an existing vertex cannot be silently substituted for a new one.
+  """
+
+  defexception [:identity, :existing, :incoming, :context]
+
+  @type t :: %__MODULE__{
+          identity: term(),
+          existing: map() | nil,
+          incoming: map() | nil,
+          context: atom() | nil
+        }
+
+  @impl Exception
+  def message(%__MODULE__{} = error) do
+    context = error.context || :vertex_insertion
+
+    "workflow identity conflict at #{inspect(error.identity)} during #{context}"
+  end
+end

--- a/lib/workflow/input_binding.ex
+++ b/lib/workflow/input_binding.ex
@@ -21,7 +21,7 @@ defmodule Runic.Workflow.InputBinding do
         }
 
   @type t :: %__MODULE__{
-          hash: non_neg_integer(),
+          hash: Runic.Identity.t(),
           target_component_hash: term(),
           source_order: list(term()),
           bindings: list(binding()),
@@ -39,7 +39,8 @@ defmodule Runic.Workflow.InputBinding do
     input_ports = Keyword.fetch!(opts, :input_ports)
 
     hash =
-      Components.fact_hash(
+      Components.identity(
+        :connection_definition,
         {__MODULE__, target_component_hash, source_order, bindings, input_ports}
       )
 

--- a/lib/workflow/invokable.ex
+++ b/lib/workflow/invokable.ex
@@ -130,13 +130,10 @@ defprotocol Runic.Workflow.Invokable do
           result_fact = Fact.new(value: result, ancestry: {node.hash, fact.hash})
 
           events = [
-            %FactProduced{
-              hash: result_fact.hash,
-              value: result_fact.value,
-              ancestry: result_fact.ancestry,
+            FactProduced.new(result_fact,
               producer_label: :produced,
               weight: ctx.ancestry_depth + 1
-            },
+            ),
             %ActivationConsumed{
               fact_hash: fact.hash,
               node_hash: node.hash,
@@ -234,13 +231,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Root do
 
   def execute(%Root{} = _root, %Runnable{input_fact: fact} = runnable) do
     events = [
-      %FactProduced{
-        hash: fact.hash,
-        value: fact.value,
-        ancestry: fact.ancestry,
+      FactProduced.new(fact,
         producer_label: :input,
         weight: 0
-      }
+      )
     ]
 
     Runnable.complete(runnable, fact, events)
@@ -476,13 +470,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Step do
 
   defp build_events(step, input_fact, result_fact, ctx) do
     events = [
-      %FactProduced{
-        hash: result_fact.hash,
-        value: result_fact.value,
-        ancestry: result_fact.ancestry,
+      FactProduced.new(result_fact,
         producer_label: :produced,
         weight: ctx.ancestry_depth + 1
-      },
+      ),
       %ActivationConsumed{
         fact_hash: input_fact.hash,
         node_hash: step.hash,
@@ -706,14 +697,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.InputBinding do
         )
 
       events = [
-        %FactProduced{
-          hash: result_fact.hash,
-          value: result_fact.value,
-          ancestry: result_fact.ancestry,
+        FactProduced.new(result_fact,
           producer_label: :produced,
-          weight: ctx.ancestry_depth + 1,
-          meta: result_fact.meta
-        },
+          weight: ctx.ancestry_depth + 1
+        ),
         %ActivationConsumed{
           fact_hash: fact.hash,
           node_hash: binding.hash,
@@ -904,13 +891,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Accumulator do
         case HookRunner.run_after(ctx, acc, fact, next_state_produced_fact) do
           {:ok, after_apply_fns} ->
             events = [
-              %FactProduced{
-                hash: next_state_produced_fact.hash,
-                value: next_state_produced_fact.value,
-                ancestry: next_state_produced_fact.ancestry,
+              FactProduced.new(next_state_produced_fact,
                 producer_label: :state_produced,
                 weight: ctx.ancestry_depth + 1
-              },
+              ),
               %ActivationConsumed{
                 fact_hash: fact.hash,
                 node_hash: acc.hash,
@@ -946,13 +930,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.Accumulator do
                 init_ancestry: init_fact.ancestry,
                 weight: ctx.ancestry_depth + 1
               },
-              %FactProduced{
-                hash: next_state_produced_fact.hash,
-                value: next_state_produced_fact.value,
-                ancestry: next_state_produced_fact.ancestry,
+              FactProduced.new(next_state_produced_fact,
                 producer_label: :state_produced,
                 weight: ctx.ancestry_depth + 1
-              },
+              ),
               %ActivationConsumed{
                 fact_hash: fact.hash,
                 node_hash: acc.hash,
@@ -1172,6 +1153,7 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.FanOut do
 
   alias Runic.Workflow.{
     Fact,
+    FactAncestry,
     FanOut,
     Runnable,
     CausalContext
@@ -1191,9 +1173,22 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.FanOut do
 
       causal_depth = Workflow.ancestry_depth(workflow, source_fact) + 1
 
-      Enum.reduce(source_fact.value, workflow, fn value, wrk ->
+      source_fact.value
+      |> Enum.with_index()
+      |> Enum.reduce(workflow, fn {value, output_index}, wrk ->
+        causal_ancestry =
+          FactAncestry.from_legacy(
+            {fan_out.hash, source_fact.hash},
+            output_port: :fan_out,
+            output_index: output_index
+          )
+
         fact =
-          Fact.new(value: value, ancestry: {fan_out.hash, source_fact.hash})
+          Fact.new(
+            value: value,
+            ancestry: {fan_out.hash, source_fact.hash},
+            causal_ancestry: causal_ancestry
+          )
 
         wrk
         |> Workflow.log_fact(fact)
@@ -1230,8 +1225,23 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.FanOut do
 
   def execute(%FanOut{} = fan_out, %Runnable{input_fact: source_fact, context: ctx} = runnable) do
     emitted_facts =
-      Enum.map(Enum.to_list(source_fact.value), fn value ->
-        Fact.new(value: value, ancestry: {fan_out.hash, source_fact.hash})
+      source_fact.value
+      |> Enum.to_list()
+      |> Enum.with_index()
+      |> Enum.map(fn {value, output_index} ->
+        causal_ancestry =
+          FactAncestry.from_legacy(
+            {fan_out.hash, source_fact.hash},
+            activation_id: runnable.activation_id,
+            output_port: :fan_out,
+            output_index: output_index
+          )
+
+        Fact.new(
+          value: value,
+          ancestry: {fan_out.hash, source_fact.hash},
+          causal_ancestry: causal_ancestry
+        )
       end)
 
     fan_out_events =
@@ -1240,8 +1250,11 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.FanOut do
           fan_out_hash: fan_out.hash,
           source_fact_hash: source_fact.hash,
           emitted_fact_hash: fact.hash,
+          emitted_content_digest: fact.content_digest,
+          emitted_payload_digest: fact.payload_digest,
           emitted_value: fact.value,
           emitted_ancestry: fact.ancestry,
+          emitted_causal_ancestry: fact.causal_ancestry,
           weight: ctx.ancestry_depth + 1
         }
       end)
@@ -1654,13 +1667,10 @@ defimpl Runic.Workflow.Invokable, for: Runic.Workflow.FanIn do
           case HookRunner.run_after(ctx, fan_in, fact, reduced_fact) do
             {:ok, after_apply_fns} ->
               events = [
-                %FactProduced{
-                  hash: reduced_fact.hash,
-                  value: reduced_fact.value,
-                  ancestry: reduced_fact.ancestry,
+                FactProduced.new(reduced_fact,
                   producer_label: :reduced,
                   weight: ctx.ancestry_depth + 1
-                },
+                ),
                 %ActivationConsumed{
                   fact_hash: fact.hash,
                   node_hash: fan_in.hash,

--- a/lib/workflow/policy_driver.ex
+++ b/lib/workflow/policy_driver.ex
@@ -54,6 +54,8 @@ defmodule Runic.Workflow.PolicyDriver do
   # ---------------------------------------------------------------------------
 
   defp do_execute(%Runnable{} = runnable, %SchedulerPolicy{} = policy, attempt, opts) do
+    runnable = Runnable.for_attempt(runnable, attempt)
+
     case check_deadline(opts) do
       :ok ->
         result = execute_with_timeout(runnable, policy, opts)
@@ -95,6 +97,8 @@ defmodule Runic.Workflow.PolicyDriver do
   # ---------------------------------------------------------------------------
 
   defp do_execute_with_events(%Runnable{} = runnable, %SchedulerPolicy{} = policy, attempt, opts) do
+    runnable = Runnable.for_attempt(runnable, attempt)
+
     case check_deadline(opts) do
       :ok ->
         dispatched_event = build_dispatched_event(runnable, policy, attempt)
@@ -168,6 +172,8 @@ defmodule Runic.Workflow.PolicyDriver do
   defp build_dispatched_event(%Runnable{} = runnable, %SchedulerPolicy{} = policy, attempt) do
     %RunnableDispatched{
       runnable_id: runnable.id,
+      activation_id: runnable.activation_id,
+      attempt_id: runnable.attempt_id,
       node_name: Map.get(runnable.node, :name, runnable.node.hash),
       node_hash: runnable.node.hash,
       input_fact: runnable.input_fact,
@@ -180,6 +186,8 @@ defmodule Runic.Workflow.PolicyDriver do
   defp build_completed_event(%Runnable{} = runnable, attempt, duration_ms) do
     %RunnableCompleted{
       runnable_id: runnable.id,
+      activation_id: runnable.activation_id,
+      attempt_id: runnable.attempt_id,
       node_hash: runnable.node.hash,
       result_fact: runnable.result,
       completed_at: System.monotonic_time(:millisecond),
@@ -191,6 +199,8 @@ defmodule Runic.Workflow.PolicyDriver do
   defp build_failed_event(%Runnable{} = runnable, attempts, failure_action) do
     %RunnableFailed{
       runnable_id: runnable.id,
+      activation_id: runnable.activation_id,
+      attempt_id: runnable.attempt_id,
       node_hash: runnable.node.hash,
       error: runnable.error,
       failed_at: System.monotonic_time(:millisecond),
@@ -310,13 +320,10 @@ defmodule Runic.Workflow.PolicyDriver do
         alias Runic.Workflow.Events.{FactProduced, ActivationConsumed}
 
         events = [
-          %FactProduced{
-            hash: result_fact.hash,
-            value: result_fact.value,
-            ancestry: result_fact.ancestry,
+          FactProduced.new(result_fact,
             producer_label: :produced,
             weight: (runnable.context.ancestry_depth || 0) + 1
-          },
+          ),
           %ActivationConsumed{
             fact_hash: runnable.input_fact.hash,
             node_hash: runnable.node.hash,

--- a/lib/workflow/private.ex
+++ b/lib/workflow/private.ex
@@ -239,10 +239,29 @@ defmodule Runic.Workflow.Private do
   end
 
   defp equivalent_fact_identity?(
+         %Fact{id: %Runic.Identity{} = id} = existing,
+         %Fact{id: id} = incoming
+       ) do
+    existing.value === incoming.value and
+      existing.content_digest == incoming.content_digest and
+      existing.payload_digest == incoming.payload_digest and
+      existing.causal_ancestry == incoming.causal_ancestry
+  end
+
+  defp equivalent_fact_identity?(
          %Fact{value: value, ancestry: ancestry},
          %Fact{value: value, ancestry: ancestry}
        ),
        do: true
+
+  defp equivalent_fact_identity?(
+         %FactRef{id: %Runic.Identity{} = id} = existing,
+         %FactRef{id: id} = incoming
+       ) do
+    existing.content_digest == incoming.content_digest and
+      existing.payload_digest == incoming.payload_digest and
+      existing.causal_ancestry == incoming.causal_ancestry
+  end
 
   defp equivalent_fact_identity?(
          %FactRef{ancestry: ancestry},
@@ -253,11 +272,24 @@ defmodule Runic.Workflow.Private do
   defp equivalent_fact_identity?(_existing, _incoming), do: false
 
   defp identity_summary(%Fact{} = fact) do
-    %{type: Fact, hash: fact.hash, ancestry: fact.ancestry, value_type: value_type(fact.value)}
+    %{
+      type: Fact,
+      hash: fact.hash,
+      content_digest: fact.content_digest,
+      payload_digest: fact.payload_digest,
+      ancestry: fact.ancestry,
+      value_type: value_type(fact.value)
+    }
   end
 
   defp identity_summary(%FactRef{} = ref) do
-    %{type: FactRef, hash: ref.hash, ancestry: ref.ancestry}
+    %{
+      type: FactRef,
+      hash: ref.hash,
+      content_digest: ref.content_digest,
+      payload_digest: ref.payload_digest,
+      ancestry: ref.ancestry
+    }
   end
 
   defp identity_summary(%{__struct__: type, hash: hash}), do: %{type: type, hash: hash}
@@ -368,6 +400,10 @@ defmodule Runic.Workflow.Private do
 
   defp resolve_component_to_node(%Workflow{graph: g}, hash) when is_integer(hash) do
     Map.get(g.vertices, hash)
+  end
+
+  defp resolve_component_to_node(%Workflow{graph: g}, %Runic.Identity{} = identity) do
+    Map.get(g.vertices, identity)
   end
 
   defp get_before_hooks(%Workflow{} = workflow, hash) do
@@ -677,7 +713,7 @@ defmodule Runic.Workflow.Private do
 
   defp resolve_target_node(workflow, target) do
     case target do
-      hash when is_integer(hash) ->
+      hash when is_integer(hash) or is_struct(hash, Runic.Identity) ->
         Map.get(workflow.graph.vertices, hash)
 
       name when is_atom(name) ->

--- a/lib/workflow/private.ex
+++ b/lib/workflow/private.ex
@@ -9,6 +9,8 @@ defmodule Runic.Workflow.Private do
   alias Runic.Workflow.Condition
   alias Runic.Workflow.Fact
   alias Runic.Workflow.FactRef
+  alias Runic.Workflow.Components
+  alias Runic.Workflow.IdentityConflictError
   alias Runic.Workflow.Rule
   alias Runic.Workflow.FanOut
   alias Runic.Workflow.FanIn
@@ -215,19 +217,65 @@ defmodule Runic.Workflow.Private do
     end
   end
 
-  def log_fact(%Workflow{graph: graph} = wrk, %Fact{} = fact) do
-    %Workflow{
-      wrk
-      | graph: Multigraph.add_vertex(graph, fact)
-    }
+  def log_fact(%Workflow{graph: graph} = workflow, fact)
+      when is_struct(fact, Fact) or is_struct(fact, FactRef) do
+    identity = Components.vertex_id_of(fact)
+
+    case Map.fetch(graph.vertices, identity) do
+      :error ->
+        %Workflow{workflow | graph: Multigraph.add_vertex(graph, fact)}
+
+      {:ok, existing} ->
+        if equivalent_fact_identity?(existing, fact) do
+          workflow
+        else
+          raise IdentityConflictError,
+            identity: identity,
+            existing: identity_summary(existing),
+            incoming: identity_summary(fact),
+            context: :log_fact
+        end
+    end
   end
 
-  def log_fact(%Workflow{graph: graph} = wrk, %FactRef{} = ref) do
-    %Workflow{
-      wrk
-      | graph: Multigraph.add_vertex(graph, ref)
-    }
+  defp equivalent_fact_identity?(
+         %Fact{value: value, ancestry: ancestry},
+         %Fact{value: value, ancestry: ancestry}
+       ),
+       do: true
+
+  defp equivalent_fact_identity?(
+         %FactRef{ancestry: ancestry},
+         %FactRef{ancestry: ancestry}
+       ),
+       do: true
+
+  defp equivalent_fact_identity?(_existing, _incoming), do: false
+
+  defp identity_summary(%Fact{} = fact) do
+    %{type: Fact, hash: fact.hash, ancestry: fact.ancestry, value_type: value_type(fact.value)}
   end
+
+  defp identity_summary(%FactRef{} = ref) do
+    %{type: FactRef, hash: ref.hash, ancestry: ref.ancestry}
+  end
+
+  defp identity_summary(%{__struct__: type, hash: hash}), do: %{type: type, hash: hash}
+  defp identity_summary(other), do: %{type: value_type(other)}
+
+  defp value_type(value) when is_boolean(value), do: :boolean
+  defp value_type(value) when is_atom(value), do: :atom
+  defp value_type(value) when is_binary(value), do: :binary
+  defp value_type(value) when is_bitstring(value), do: :bitstring
+  defp value_type(value) when is_float(value), do: :float
+  defp value_type(value) when is_function(value), do: :function
+  defp value_type(value) when is_integer(value), do: :integer
+  defp value_type(value) when is_list(value), do: :list
+  defp value_type(value) when is_map(value), do: :map
+  defp value_type(value) when is_pid(value), do: :pid
+  defp value_type(value) when is_port(value), do: :port
+  defp value_type(value) when is_reference(value), do: :reference
+  defp value_type(value) when is_tuple(value), do: :tuple
 
   # =============================================================================
   # Hooks

--- a/lib/workflow/rule.ex
+++ b/lib/workflow/rule.ex
@@ -25,11 +25,11 @@ defmodule Runic.Workflow.Rule do
           name: String.t(),
           arity: arity(),
           workflow: Workflow.t(),
-          hash: integer(),
-          condition_hash: integer(),
-          reaction_hash: integer(),
+          hash: Runic.Identity.t() | integer() | binary(),
+          condition_hash: Runic.Identity.t() | integer() | binary(),
+          reaction_hash: Runic.Identity.t() | integer() | binary(),
           closure: Closure.t() | nil,
-          condition_refs: [{atom(), integer()}]
+          condition_refs: [{atom(), term()}]
         }
 
   def new(opts \\ []) do

--- a/lib/workflow/runnable.ex
+++ b/lib/workflow/runnable.ex
@@ -19,13 +19,17 @@ defmodule Runic.Workflow.Runnable do
   - After execution: result, status, and events for reducing into workflow
   """
 
-  alias Runic.Workflow.{CausalContext, Components, Fact}
+  alias Runic.Identity
+  alias Runic.Workflow.{CausalContext, Fact}
   alias Runic.Workflow.Invocation.Plan
 
   @type status :: :pending | :completed | :failed | :skipped
 
   @type t :: %__MODULE__{
-          id: integer() | nil,
+          id: term() | nil,
+          activation_id: Identity.t() | nil,
+          attempt_id: Identity.t() | nil,
+          attempt_number: non_neg_integer(),
           node: struct(),
           input_fact: Fact.t(),
           context: CausalContext.t() | nil,
@@ -39,6 +43,9 @@ defmodule Runic.Workflow.Runnable do
 
   defstruct [
     :id,
+    :activation_id,
+    :attempt_id,
+    :attempt_number,
     :node,
     :input_fact,
     :context,
@@ -58,8 +65,13 @@ defmodule Runic.Workflow.Runnable do
   """
   @spec new(struct(), Fact.t(), CausalContext.t()) :: t()
   def new(node, fact, context) do
+    activation_id = runnable_id(node, fact)
+
     %__MODULE__{
-      id: runnable_id(node, fact),
+      id: activation_id,
+      activation_id: activation_id,
+      attempt_id: Identity.derive(:attempt, [activation_id, 0]),
+      attempt_number: 0,
       node: node,
       input_fact: fact,
       context: context,
@@ -70,10 +82,13 @@ defmodule Runic.Workflow.Runnable do
   @doc """
   Creates a new Runnable with explicit id.
   """
-  @spec new(integer(), struct(), Fact.t(), CausalContext.t()) :: t()
+  @spec new(term(), struct(), Fact.t(), CausalContext.t()) :: t()
   def new(id, node, fact, context) do
     %__MODULE__{
       id: id,
+      activation_id: if(is_struct(id, Identity), do: id),
+      attempt_id: if(is_struct(id, Identity), do: Identity.derive(:attempt, [id, 0])),
+      attempt_number: 0,
       node: node,
       input_fact: fact,
       context: context,
@@ -90,10 +105,22 @@ defmodule Runic.Workflow.Runnable do
   @doc """
   Generates a stable runnable id from node and fact hashes.
   """
-  @spec runnable_id(struct(), Fact.t()) :: integer()
+  @spec runnable_id(struct(), Fact.t()) :: Identity.t()
   def runnable_id(node, fact) do
-    Components.fact_hash({:runnable, node.hash, fact.hash})
+    Identity.derive(:activation, [:local, fact.hash, node.hash])
   end
+
+  @doc false
+  @spec for_attempt(t(), non_neg_integer()) :: t()
+  def for_attempt(%__MODULE__{activation_id: %Identity{} = activation_id} = runnable, attempt) do
+    %{
+      runnable
+      | attempt_number: attempt,
+        attempt_id: Identity.derive(:attempt, [activation_id, attempt])
+    }
+  end
+
+  def for_attempt(%__MODULE__{} = runnable, attempt), do: %{runnable | attempt_number: attempt}
 
   @doc """
   Marks a runnable as completed with result and events.

--- a/lib/workflow/runnable.ex
+++ b/lib/workflow/runnable.ex
@@ -19,7 +19,7 @@ defmodule Runic.Workflow.Runnable do
   - After execution: result, status, and events for reducing into workflow
   """
 
-  alias Runic.Workflow.{Fact, CausalContext}
+  alias Runic.Workflow.{CausalContext, Components, Fact}
   alias Runic.Workflow.Invocation.Plan
 
   @type status :: :pending | :completed | :failed | :skipped
@@ -53,12 +53,13 @@ defmodule Runic.Workflow.Runnable do
   @doc """
   Creates a new Runnable in pending state.
 
-  The id is a hash of {node.hash, fact.hash} for idempotency tracking.
+  The id is a domain-separated hash of the node and Fact identities for
+  idempotency tracking.
   """
   @spec new(struct(), Fact.t(), CausalContext.t()) :: t()
   def new(node, fact, context) do
     %__MODULE__{
-      id: :erlang.phash2({node.hash, fact.hash}),
+      id: runnable_id(node, fact),
       node: node,
       input_fact: fact,
       context: context,
@@ -91,7 +92,7 @@ defmodule Runic.Workflow.Runnable do
   """
   @spec runnable_id(struct(), Fact.t()) :: integer()
   def runnable_id(node, fact) do
-    :erlang.phash2({node.hash, fact.hash})
+    Components.fact_hash({:runnable, node.hash, fact.hash})
   end
 
   @doc """

--- a/lib/workflow/runnable_completed.ex
+++ b/lib/workflow/runnable_completed.ex
@@ -11,7 +11,9 @@ defmodule Runic.Workflow.RunnableCompleted do
 
   @type t :: %__MODULE__{
           runnable_id: term(),
-          node_hash: non_neg_integer(),
+          activation_id: Runic.Identity.t() | nil,
+          attempt_id: Runic.Identity.t() | nil,
+          node_hash: term(),
           result_fact: Runic.Workflow.Fact.t(),
           completed_at: integer(),
           attempt: non_neg_integer(),
@@ -20,6 +22,8 @@ defmodule Runic.Workflow.RunnableCompleted do
 
   defstruct [
     :runnable_id,
+    :activation_id,
+    :attempt_id,
     :node_hash,
     :result_fact,
     :completed_at,

--- a/lib/workflow/runnable_dispatched.ex
+++ b/lib/workflow/runnable_dispatched.ex
@@ -8,8 +8,10 @@ defmodule Runic.Workflow.RunnableDispatched do
 
   @type t :: %__MODULE__{
           runnable_id: term(),
+          activation_id: Runic.Identity.t() | nil,
+          attempt_id: Runic.Identity.t() | nil,
           node_name: atom() | binary() | nil,
-          node_hash: non_neg_integer(),
+          node_hash: term(),
           input_fact: Runic.Workflow.Fact.t(),
           dispatched_at: integer(),
           policy: Runic.Workflow.SchedulerPolicy.t(),
@@ -18,6 +20,8 @@ defmodule Runic.Workflow.RunnableDispatched do
 
   defstruct [
     :runnable_id,
+    :activation_id,
+    :attempt_id,
     :node_name,
     :node_hash,
     :input_fact,

--- a/lib/workflow/runnable_failed.ex
+++ b/lib/workflow/runnable_failed.ex
@@ -11,7 +11,9 @@ defmodule Runic.Workflow.RunnableFailed do
 
   @type t :: %__MODULE__{
           runnable_id: term(),
-          node_hash: non_neg_integer(),
+          activation_id: Runic.Identity.t() | nil,
+          attempt_id: Runic.Identity.t() | nil,
+          node_hash: term(),
           error: term(),
           failed_at: integer(),
           attempts: non_neg_integer(),
@@ -20,6 +22,8 @@ defmodule Runic.Workflow.RunnableFailed do
 
   defstruct [
     :runnable_id,
+    :activation_id,
+    :attempt_id,
     :node_hash,
     :error,
     :failed_at,

--- a/lib/workflow/serializer.ex
+++ b/lib/workflow/serializer.ex
@@ -37,11 +37,13 @@ defmodule Runic.Workflow.Serializer do
   @doc """
   Returns a unique, Mermaid-safe node ID for a vertex.
   """
+  def node_id(%{hash: %Runic.Identity{} = identity}), do: identity_node_id(identity)
   def node_id(%{hash: hash}) when is_integer(hash), do: "n#{hash}"
-  def node_id(%{hash: hash}) when is_binary(hash), do: "n#{:erlang.phash2(hash)}"
+  def node_id(%{hash: hash}) when is_binary(hash), do: binary_node_id(hash)
   def node_id(%Runic.Workflow.Root{}), do: "root"
+  def node_id(%Runic.Identity{} = identity), do: identity_node_id(identity)
   def node_id(hash) when is_integer(hash), do: "n#{hash}"
-  def node_id(other), do: "n#{:erlang.phash2(other)}"
+  def node_id(other), do: other |> :erlang.term_to_binary([:deterministic]) |> binary_node_id()
 
   @doc """
   Returns a display label for a vertex node.
@@ -138,6 +140,13 @@ defmodule Runic.Workflow.Serializer do
   def node_class(%Runic.Workflow.Conjunction{}), do: "conjunction"
   def node_class(%Runic.Workflow.Fact{}), do: "fact"
   def node_class(_), do: "default"
+
+  defp identity_node_id(identity), do: "n_" <> Runic.Identity.short_string(identity, 24)
+
+  defp binary_node_id(binary) do
+    identity = Runic.Identity.digest(:node_occurrence, {:display_binary, binary})
+    identity_node_id(identity)
+  end
 
   @doc """
   Escapes special characters for Mermaid labels.

--- a/lib/workflow/serializers/cytoscape.ex
+++ b/lib/workflow/serializers/cytoscape.ex
@@ -136,6 +136,10 @@ defmodule Runic.Workflow.Serializers.Cytoscape do
     }
   end
 
+  defp add_hash_if_present(data, %{hash: %Runic.Identity{} = identity}) do
+    Map.put(data, :hash, Runic.Identity.to_string(identity))
+  end
+
   defp add_hash_if_present(data, %{hash: hash}), do: Map.put(data, :hash, hash)
   defp add_hash_if_present(data, _), do: data
 

--- a/lib/workflow/serializers/edgelist.ex
+++ b/lib/workflow/serializers/edgelist.ex
@@ -86,7 +86,7 @@ defmodule Runic.Workflow.Serializers.Edgelist do
   defp vertex_name(%Workflow.Root{}), do: :root
   defp vertex_name(%{name: name}) when not is_nil(name), do: name
   defp vertex_name(%{hash: hash}), do: hash
-  defp vertex_name(other), do: :erlang.phash2(other)
+  defp vertex_name(other), do: Serializer.node_id(other)
 
   defp edges_to_string(edges) do
     edges
@@ -99,5 +99,6 @@ defmodule Runic.Workflow.Serializers.Edgelist do
   defp format_name(name) when is_atom(name), do: Atom.to_string(name)
   defp format_name(name) when is_binary(name), do: name
   defp format_name(name) when is_integer(name), do: "n#{name}"
+  defp format_name(%Runic.Identity{} = identity), do: Runic.Identity.to_string(identity)
   defp format_name(name), do: inspect(name)
 end

--- a/lib/workflow/step.ex
+++ b/lib/workflow/step.ex
@@ -37,7 +37,7 @@ defmodule Runic.Workflow.Step do
 
   @type meta_ref :: %{
           kind: atom(),
-          target: atom() | integer() | {atom(), atom()},
+          target: atom() | Runic.Identity.t() | integer() | {atom(), atom()},
           field_path: list(atom()),
           context_key: atom()
         }
@@ -45,8 +45,8 @@ defmodule Runic.Workflow.Step do
   @type t :: %__MODULE__{
           name: String.t() | atom(),
           work: function(),
-          hash: String.t() | nil,
-          work_hash: String.t() | nil,
+          hash: Runic.Identity.t() | integer() | binary() | nil,
+          work_hash: Runic.Identity.t() | integer() | binary() | nil,
           closure: Closure.t() | nil,
           inputs: term(),
           outputs: term(),

--- a/test/condition_component_test.exs
+++ b/test/condition_component_test.exs
@@ -295,7 +295,7 @@ defmodule ConditionComponentTest do
 
       assert conj.condition_hashes == MapSet.new([inline_cond.hash])
       assert conj.condition_refs == [:ham]
-      assert is_integer(conj.hash)
+      assert %Runic.Identity{domain: :component_definition} = conj.hash
     end
 
     test "Conjunction.new/2 produces stable hashes" do
@@ -323,7 +323,7 @@ defmodule ConditionComponentTest do
         end
 
       assert %Rule{} = rule
-      assert is_integer(rule.hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.hash
     end
 
     test "rule with condition ref has conjunction with condition_refs" do
@@ -477,7 +477,7 @@ defmodule ConditionComponentTest do
         end
 
       assert %Rule{} = rule
-      assert is_integer(rule.hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.hash
     end
 
     test "rule with || syntax compiles" do
@@ -626,7 +626,7 @@ defmodule ConditionComponentTest do
           then(fn %{value: v} -> {:result, v} end)
         end
 
-      assert is_integer(rule.condition_hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.condition_hash
     end
 
     test "condition_hash is consistent within a single or rule" do
@@ -637,7 +637,7 @@ defmodule ConditionComponentTest do
           then(fn %{value: v} -> {:result, v} end)
         end
 
-      assert is_integer(rule.condition_hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.condition_hash
       assert rule.condition_hash != rule.reaction_hash
     end
   end

--- a/test/identity_regression_test.exs
+++ b/test/identity_regression_test.exs
@@ -1,0 +1,190 @@
+defmodule Runic.IdentityRegressionTest do
+  use ExUnit.Case, async: true
+
+  require Runic
+
+  alias Runic.Identity
+  alias Runic.Identity.{Canonical, IntegrityError}
+  alias Runic.Workflow
+  alias Runic.Workflow.{Fact, FactResolver, Facts, Step}
+  alias Runic.Workflow.Events.FactProduced
+
+  test "projected structs cannot alias ordinary tuples, including as map keys" do
+    range = 1..3
+    tuple = {:projected, Range, %{first: 1, last: 3, step: 1}}
+
+    refute Canonical.encode!(range) == Canonical.encode!(tuple)
+    refute Canonical.encode!(range) == Canonical.encode!({Range, %{first: 1, last: 3, step: 1}})
+    refute Canonical.encode!(%{range => :value}) == Canonical.encode!(%{tuple => :value})
+
+    first = Fact.new(value: range)
+    second = Fact.new(value: tuple)
+    refute first.payload_digest == second.payload_digest
+    refute first.id == second.id
+
+    workflow = Workflow.new() |> Workflow.log_fact(first) |> Workflow.log_fact(second)
+    assert length(Workflow.facts(workflow)) == 2
+
+    resolver = %FactResolver{cache: %{first.hash => tuple}}
+
+    assert {:error, %IntegrityError{}} = FactResolver.resolve(Facts.to_ref(first), resolver)
+  end
+
+  test "all step macro forms support pinned external captures and replay" do
+    mapper = &Enum.sum/1
+
+    steps = [
+      Runic.step(fn values -> (^mapper).(values) end),
+      Runic.step(work: fn values -> (^mapper).(values) end, name: :keyword_sum),
+      Runic.step(fn values -> (^mapper).(values) end, name: :named_sum)
+    ]
+
+    for step <- steps do
+      assert Step.run(step, [1, 2, 3]) == 6
+      workflow = Workflow.new() |> Workflow.add(step)
+      rebuilt = workflow |> Workflow.build_log() |> Workflow.from_log()
+      restored = Workflow.get_component(rebuilt, step.name)
+      assert restored.hash == step.hash
+      assert Step.run(restored, [1, 2, 3]) == 6
+      assert Runic.Component.hash(rebuilt) == Runic.Component.hash(workflow)
+    end
+  end
+
+  test "nested external captures survive binding projection" do
+    config = %{mappers: [&Enum.sum/1]}
+    step = Runic.step(fn values -> hd((^config).mappers).(values) end)
+    assert Step.run(step, [1, 2]) == 3
+  end
+
+  test "function bindings cannot alias literal MFA tuples" do
+    source = quote(do: fn -> binding end)
+    function = Runic.Closure.new(source, %{binding: &Enum.sum/1}, nil)
+    tuple = Runic.Closure.new(source, %{binding: {:mfa, Enum, :sum, 1}}, nil)
+    refute function.hash == tuple.hash
+    refute Runic.Closure.identity_bindings(function) == Runic.Closure.identity_bindings(tuple)
+  end
+
+  test "condition, reduce and accumulator macros support pinned external captures" do
+    predicate = &Enum.empty?/1
+    combiner = &Kernel.+/2
+
+    for condition <- [
+          Runic.condition(fn values -> (^predicate).(values) end),
+          Runic.condition(fn values -> (^predicate).(values) end, name: :empty)
+        ] do
+      assert condition.work.([])
+      refute condition.work.([1])
+    end
+
+    reduce = Runic.reduce(0, fn value, acc -> (^combiner).(value, acc) end)
+    accumulator = Runic.accumulator(0, fn value, acc -> (^combiner).(value, acc) end)
+    assert reduce.fan_in.reducer.(2, 3) == 5
+    assert accumulator.reducer.(2, 3) == 5
+  end
+
+  test "workflow artifacts distinguish call contracts with different execution behavior" do
+    work = fn input, context -> {input, context} end
+    positional = Step.new(name: :example, work: work)
+
+    contextual =
+      Step.new(
+        name: :example,
+        work: work,
+        meta_refs: [%{kind: :context, target: nil, context_key: :config, field_path: []}]
+      )
+
+    assert positional.hash == contextual.hash
+    assert Step.run_with_meta_context(positional, [1, 2], %{config: 3}) == {1, 2}
+    assert Step.run_with_meta_context(contextual, [1, 2], %{config: 3}) == {[1, 2], %{config: 3}}
+    refute artifact(positional) == artifact(contextual)
+  end
+
+  test "workflow artifacts include port contracts and executable definitions behind explicit keys" do
+    first = Step.new(name: :value, work: &Function.identity/1, outputs: [value: :integer])
+    second = Step.new(name: :value, work: &Function.identity/1, outputs: [value: :string])
+    assert first.hash == second.hash
+    refute artifact(first) == artifact(second)
+
+    first = Step.new(name: :value, hash: 42, work: fn value -> value + 1 end)
+    second = Step.new(name: :value, hash: 42, work: fn value -> value + 2 end)
+    refute artifact(first) == artifact(second)
+  end
+
+  test "workflow artifact identity survives execution and runtime context changes" do
+    workflow = Workflow.new() |> Workflow.add(Runic.map(fn value -> value * 2 end, name: :double))
+    digest = Runic.Component.hash(workflow)
+
+    executed =
+      workflow
+      |> Workflow.put_run_context(%{_global: %{runtime: :value}})
+      |> Workflow.react_until_satisfied([1, 2])
+
+    assert Runic.Component.hash(executed) == digest
+  end
+
+  test "Cytoscape elements encode full typed hashes as JSON strings" do
+    step = Step.new(name: :echo, work: &Function.identity/1)
+    workflow = Workflow.new() |> Workflow.add(step) |> Workflow.react_until_satisfied(42)
+    elements = Workflow.to_cytoscape(workflow, include_facts: true, include_memory: true)
+    decoded = elements |> JSON.encode!() |> JSON.decode!()
+    node = Enum.find(decoded, &(&1["data"]["name"] == "echo" and &1["data"]["hash"] != nil))
+
+    assert node["data"]["hash"] == Identity.to_string(step.hash)
+
+    assert Enum.any?(
+             decoded,
+             &String.starts_with?(&1["data"]["hash"] || "", "runic:sha256:v1:fact_occurrence:")
+           )
+  end
+
+  test "explicit Fact IDs distinguish equal inputs and survive replay and hydration" do
+    first_id = Identity.derive(:fact_occurrence, [:first_ingress])
+    second_id = Identity.derive(:fact_occurrence, [:second_ingress])
+    first = Fact.new(id: first_id, value: :same)
+    second = Fact.new(id: second_id, value: :same)
+
+    assert first.id == first_id
+    assert first.hash == first_id
+    assert second.id == second_id
+    assert first.payload_digest == second.payload_digest
+
+    events = Enum.map([first, second], &FactProduced.new(&1, producer_label: :input, weight: 0))
+    replayed = Workflow.from_events(events)
+    assert MapSet.new(Workflow.facts(replayed), & &1.id) == MapSet.new([first_id, second_id])
+
+    lean = Workflow.from_events(Enum.map(events, &%{&1 | value: nil}), nil, fact_mode: :ref)
+    resolver = %FactResolver{cache: %{first_id => :same, second_id => :same}}
+
+    for id <- [first_id, second_id] do
+      assert {:ok, %Fact{id: ^id, hash: ^id, value: :same}} =
+               FactResolver.resolve(Map.fetch!(lean.graph.vertices, id), resolver)
+    end
+  end
+
+  test "Fact constructor reconciles compatibility hashes and rejects invalid or conflicting IDs" do
+    id = Identity.derive(:fact_occurrence, [:input])
+    other = Identity.derive(:fact_occurrence, [:other])
+    assert Fact.new(id: id, hash: id, value: 1).id == id
+    assert Fact.new(hash: id, value: 1).id == id
+    assert Fact.new(hash: 42, value: 1).hash == 42
+
+    for hash <- [other, 42] do
+      assert_raise ArgumentError, ~r/id and hash must identify the same occurrence/, fn ->
+        Fact.new(id: id, hash: hash, value: 1)
+      end
+    end
+
+    for invalid <- [
+          Identity.digest(:payload, :value),
+          %{id | digest: <<1>>},
+          %{id | version: 2},
+          42
+        ] do
+      assert_raise ArgumentError, ~r/expected a valid Fact occurrence identity/, fn ->
+        Fact.new(id: invalid, value: 1)
+      end
+    end
+  end
+
+  defp artifact(step), do: Workflow.new() |> Workflow.add(step) |> Runic.Component.hash()
+end

--- a/test/identity_test.exs
+++ b/test/identity_test.exs
@@ -1,0 +1,183 @@
+defmodule Runic.IdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Runic.Identity
+  alias Runic.Identity.{Canonical, CanonicalError, IntegrityError, Preimage}
+  alias Runic.Workflow.{CausalContext, Fact, FanOut, Invokable, Runnable}
+
+  describe "canonical encoding v1" do
+    test "has frozen primitive and collection vectors" do
+      assert hex(Canonical.encode!(nil)) == "00"
+      assert hex(Canonical.encode!(42)) == "1000000000000000023432"
+      assert hex(Canonical.encode!(1.5)) == "113ff8000000000000"
+      assert hex(Canonical.encode!("hi")) == "2000000000000000026869"
+      assert hex(Canonical.encode!(:hi)) == "2100000000000000026869"
+
+      assert hex(Canonical.encode!([1, :a])) ==
+               "300000000000000002000000000000000a10000000000000000131" <>
+                 "000000000000000a21000000000000000161"
+
+      assert hex(Canonical.encode!({1, :a})) ==
+               "310000000000000002000000000000000a10000000000000000131" <>
+                 "000000000000000a21000000000000000161"
+    end
+
+    test "sorts maps by canonical key bytes" do
+      first = Map.new([{:b, 2}, {:a, 1}])
+      second = Map.new([{:a, 1}, {:b, 2}])
+
+      assert Canonical.encode!(first) == Canonical.encode!(second)
+      assert Identity.digest(:payload, first) == Identity.digest(:payload, second)
+    end
+
+    test "keeps logical types distinct" do
+      encodings = Enum.map([:value, "value", [:value], {:value}], &Canonical.encode!/1)
+
+      assert Enum.uniq(encodings) == encodings
+    end
+
+    test "projects registered Range values without accepting arbitrary structs" do
+      assert is_binary(Canonical.encode!(1..3))
+
+      assert_raise CanonicalError, ~r/unsupported .*URI value/, fn ->
+        Canonical.encode!(URI.parse("https://runic.dev"))
+      end
+    end
+
+    test "rejects process-local and executable terms with a useful path" do
+      assert_raise CanonicalError, ~r/at \$\[:work\].*unsupported function/, fn ->
+        Canonical.encode!(%{work: fn -> :ok end})
+      end
+
+      assert_raise CanonicalError, ~r/unsupported pid/, fn ->
+        Canonical.encode!(self())
+      end
+    end
+
+    test "enforces configured limits" do
+      assert_raise CanonicalError, ~r/depth limit exceeded/, fn ->
+        Canonical.encode!([[[1]]], max_depth: 1)
+      end
+
+      assert_raise CanonicalError, ~r/byte_size limit exceeded/, fn ->
+        Canonical.encode!("too large", max_bytes: 4)
+      end
+
+      assert_raise CanonicalError, ~r/item_count limit exceeded/, fn ->
+        Canonical.encode!([1, 2, 3], max_items: 2)
+      end
+    end
+  end
+
+  describe "typed SHA-256 identities" do
+    test "freezes the preimage frame and payload digest" do
+      canonical =
+        Canonical.encode!(%{codec: :runic_canonical, schema_version: 1, value: %{a: 1, b: 2}})
+
+      identity = Identity.digest_bytes(:payload, canonical)
+
+      assert binary_part(Preimage.frame_v1(:payload, canonical), 0, 20) ==
+               <<"runic-id", 0, 1::unsigned-16, 7::unsigned-16, "payload">>
+
+      assert Identity.to_string(identity) ==
+               "runic:sha256:v1:payload:" <>
+                 "21205882d75b9c3a549850de3b90d8347acfd5b648858d1256ad64883511b90c"
+
+      assert hex(Identity.to_binary(identity)) ==
+               "01000100077061796c6f6164" <>
+                 "21205882d75b9c3a549850de3b90d8347acfd5b648858d1256ad64883511b90c"
+    end
+
+    test "domain-separates equal identity documents" do
+      document = %{value: 42}
+
+      refute Identity.digest(:payload, document) == Identity.digest(:fact_content, document)
+    end
+
+    test "projects component semantics without occurrence names or compiled functions" do
+      first = Runic.Workflow.Step.new(name: :first, work: &Function.identity/1)
+      second = Runic.Workflow.Step.new(name: :second, work: &Function.identity/1)
+
+      assert Identity.project(:component_definition, first) ==
+               Identity.project(:component_definition, second)
+    end
+
+    test "projects external function bindings as portable MFA data" do
+      closure =
+        Runic.Closure.new(
+          quote(do: fn values -> mapper.(values) end),
+          %{mapper: &Enum.sum/1},
+          nil
+        )
+
+      assert %Identity{domain: :component_definition} =
+               Identity.project(:component_definition, closure)
+    end
+
+    test "builds a workflow artifact identity from static topology" do
+      step = Runic.Workflow.Step.new(name: :identity, work: &Function.identity/1)
+      workflow = Runic.Workflow.new(:artifact) |> Runic.Workflow.add(step)
+      with_context = Runic.Workflow.put_run_context(workflow, %{identity: %{secret: "runtime"}})
+
+      assert %Identity{domain: :workflow_artifact} = artifact = Runic.Component.hash(workflow)
+      assert Runic.Component.hash(with_context) == artifact
+    end
+
+    test "verifies content and returns a typed integrity error" do
+      expected = Identity.digest(:payload, %{value: :expected})
+
+      assert :ok = Identity.verify(expected, %{value: :expected})
+
+      assert {:error, %IntegrityError{expected: ^expected}} =
+               Identity.verify(expected, %{value: :different})
+    end
+  end
+
+  describe "content and occurrence identities" do
+    test "a Fact separates payload, causal content, and graph occurrence" do
+      fact = Fact.new(value: %{answer: 42})
+
+      assert %Identity{domain: :payload} = fact.payload_digest
+      assert %Identity{domain: :fact_content} = fact.content_digest
+      assert %Identity{domain: :fact_occurrence} = fact.id
+      assert fact.hash == fact.id
+    end
+
+    test "equal fan-out payloads share payload identity but keep distinct occurrences" do
+      fan_out = %FanOut{
+        name: :fan_out,
+        hash: Identity.digest(:component_definition, %{kind: :fan_out})
+      }
+
+      input = Fact.new(value: [:same, :same])
+      context = CausalContext.new(node_hash: fan_out.hash, input_fact: input)
+
+      executed =
+        fan_out
+        |> Runnable.new(input, context)
+        |> then(&Invokable.execute(fan_out, &1))
+
+      [first, second] = executed.result
+
+      assert first.payload_digest == second.payload_digest
+      refute first.content_digest == second.content_digest
+      refute first.id == second.id
+      assert first.causal_ancestry.output_index == 0
+      assert second.causal_ancestry.output_index == 1
+    end
+
+    test "attempt identity changes while activation identity remains stable" do
+      step = Runic.Workflow.Step.new(name: :identity, work: &Function.identity/1)
+      fact = Fact.new(value: :input)
+      runnable = Runnable.new(step, fact, CausalContext.new())
+
+      retry = Runnable.for_attempt(runnable, 1)
+
+      assert retry.activation_id == runnable.activation_id
+      refute retry.attempt_id == runnable.attempt_id
+      assert retry.attempt_number == 1
+    end
+  end
+
+  defp hex(binary), do: Base.encode16(binary, case: :lower)
+end

--- a/test/rule_dsl_test.exs
+++ b/test/rule_dsl_test.exs
@@ -33,7 +33,7 @@ defmodule Runic.RuleDSLTest do
 
       assert %Rule{} = rule
       assert is_binary(rule.name) or is_atom(rule.name)
-      assert is_integer(rule.hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.hash
     end
 
     test "compiles rule with simple binding (any type)" do

--- a/test/runic_test.exs
+++ b/test/runic_test.exs
@@ -166,8 +166,8 @@ defmodule RunicTest do
         Runic.rule(fn item when is_integer(item) and item > 41 and item < 43 -> "fourty two" end)
 
       assert match?(%Rule{}, rule)
-      assert is_integer(rule.condition_hash)
-      assert is_integer(rule.reaction_hash)
+      assert %Runic.Identity{domain: :component_definition} = rule.condition_hash
+      assert %Runic.Identity{domain: :component_definition} = rule.reaction_hash
 
       wrk_of_rule = Runic.transmute(rule)
 

--- a/test/runnable_test.exs
+++ b/test/runnable_test.exs
@@ -1,7 +1,8 @@
 defmodule Runic.Workflow.RunnableTest do
   use ExUnit.Case, async: true
 
-  alias Runic.Workflow.{CausalContext, Components, Fact, Runnable}
+  alias Runic.Identity
+  alias Runic.Workflow.{CausalContext, Fact, Runnable}
   alias Runic.Workflow.Step
 
   describe "Runnable.new/3" do
@@ -16,11 +17,12 @@ defmodule Runic.Workflow.RunnableTest do
       assert runnable.node == step
       assert runnable.input_fact == fact
       assert runnable.context == context
-      assert is_integer(runnable.id)
+      assert %Identity{domain: :activation} = runnable.id
       assert runnable.result == nil
       assert runnable.events == nil
       assert runnable.error == nil
-      assert runnable.id == Components.fact_hash({:runnable, step.hash, fact.hash})
+      assert runnable.id == Runnable.runnable_id(step, fact)
+      assert %Identity{domain: :attempt} = runnable.attempt_id
     end
 
     test "generates stable id from node and fact hashes" do
@@ -67,7 +69,7 @@ defmodule Runic.Workflow.RunnableTest do
 
       id = Runnable.runnable_id(step, fact)
 
-      assert is_integer(id)
+      assert %Identity{domain: :activation} = id
       assert id == Runnable.runnable_id(step, fact)
     end
   end

--- a/test/runnable_test.exs
+++ b/test/runnable_test.exs
@@ -1,7 +1,7 @@
 defmodule Runic.Workflow.RunnableTest do
   use ExUnit.Case, async: true
 
-  alias Runic.Workflow.{Runnable, CausalContext, Fact}
+  alias Runic.Workflow.{CausalContext, Components, Fact, Runnable}
   alias Runic.Workflow.Step
 
   describe "Runnable.new/3" do
@@ -20,6 +20,7 @@ defmodule Runic.Workflow.RunnableTest do
       assert runnable.result == nil
       assert runnable.events == nil
       assert runnable.error == nil
+      assert runnable.id == Components.fact_hash({:runnable, step.hash, fact.hash})
     end
 
     test "generates stable id from node and fact hashes" do

--- a/test/runner/store_ets_test.exs
+++ b/test/runner/store_ets_test.exs
@@ -117,12 +117,20 @@ defmodule Runic.Runner.Store.ETSTest do
       assert {:ok, "value_1"} = ETS.load_fact(:hash_1, state)
     end
 
-    test "round-trips composite workflow identities", %{store_state: state} do
-      fact = Runic.Workflow.Fact.new(value: {:composite_identity, 42})
+    test "round-trips typed workflow identities", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: {:typed_identity, 42})
 
-      assert fact.hash > 4_294_967_295
+      assert %Runic.Identity{domain: :fact_occurrence} = fact.hash
       assert :ok = ETS.save_fact(fact.hash, fact.value, state)
       assert {:ok, fact.value} == ETS.load_fact(fact.hash, state)
+    end
+
+    test "round-trips encoded payloads by payload digest", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: %{payload: 42})
+      encoded = :erlang.term_to_binary(fact.value, [:deterministic])
+
+      assert :ok = ETS.save_payload(fact.payload_digest, encoded, state)
+      assert {:ok, ^encoded} = ETS.load_payload(fact.payload_digest, state)
     end
 
     test "load_fact returns {:error, :not_found} for unknown hash", %{store_state: state} do

--- a/test/runner/store_ets_test.exs
+++ b/test/runner/store_ets_test.exs
@@ -117,6 +117,14 @@ defmodule Runic.Runner.Store.ETSTest do
       assert {:ok, "value_1"} = ETS.load_fact(:hash_1, state)
     end
 
+    test "round-trips composite workflow identities", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: {:composite_identity, 42})
+
+      assert fact.hash > 4_294_967_295
+      assert :ok = ETS.save_fact(fact.hash, fact.value, state)
+      assert {:ok, fact.value} == ETS.load_fact(fact.hash, state)
+    end
+
     test "load_fact returns {:error, :not_found} for unknown hash", %{store_state: state} do
       assert {:error, :not_found} = ETS.load_fact(:nonexistent, state)
     end

--- a/test/runner/store_mnesia_test.exs
+++ b/test/runner/store_mnesia_test.exs
@@ -144,12 +144,20 @@ defmodule Runic.Runner.Store.MnesiaTest do
       assert {:ok, "value_1"} = MnesiaStore.load_fact(:hash_1, state)
     end
 
-    test "round-trips composite workflow identities", %{store_state: state} do
-      fact = Runic.Workflow.Fact.new(value: {:composite_identity, 42})
+    test "round-trips typed workflow identities", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: {:typed_identity, 42})
 
-      assert fact.hash > 4_294_967_295
+      assert %Runic.Identity{domain: :fact_occurrence} = fact.hash
       assert :ok = MnesiaStore.save_fact(fact.hash, fact.value, state)
       assert {:ok, fact.value} == MnesiaStore.load_fact(fact.hash, state)
+    end
+
+    test "round-trips encoded payloads by payload digest", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: %{payload: 42})
+      encoded = :erlang.term_to_binary(fact.value, [:deterministic])
+
+      assert :ok = MnesiaStore.save_payload(fact.payload_digest, encoded, state)
+      assert {:ok, ^encoded} = MnesiaStore.load_payload(fact.payload_digest, state)
     end
 
     test "load_fact returns {:error, :not_found} for unknown hash", %{store_state: state} do

--- a/test/runner/store_mnesia_test.exs
+++ b/test/runner/store_mnesia_test.exs
@@ -144,6 +144,14 @@ defmodule Runic.Runner.Store.MnesiaTest do
       assert {:ok, "value_1"} = MnesiaStore.load_fact(:hash_1, state)
     end
 
+    test "round-trips composite workflow identities", %{store_state: state} do
+      fact = Runic.Workflow.Fact.new(value: {:composite_identity, 42})
+
+      assert fact.hash > 4_294_967_295
+      assert :ok = MnesiaStore.save_fact(fact.hash, fact.value, state)
+      assert {:ok, fact.value} == MnesiaStore.load_fact(fact.hash, state)
+    end
+
     test "load_fact returns {:error, :not_found} for unknown hash", %{store_state: state} do
       assert {:error, :not_found} = MnesiaStore.load_fact(:nonexistent, state)
     end

--- a/test/state_machine_test.exs
+++ b/test/state_machine_test.exs
@@ -269,8 +269,7 @@ defmodule Runic.StateMachineTest do
           reducer: fn x, acc -> acc + x end
         )
 
-      assert is_integer(sm.hash)
-      assert sm.hash != 0
+      assert %Runic.Identity{domain: :component_definition} = sm.hash
     end
 
     test "different reducers produce different hashes" do

--- a/test/workflow/fact_resolver_test.exs
+++ b/test/workflow/fact_resolver_test.exs
@@ -1,7 +1,7 @@
 defmodule Runic.Workflow.FactResolverTest do
   use ExUnit.Case, async: true
 
-  alias Runic.Workflow.{Fact, FactRef, FactResolver}
+  alias Runic.Workflow.{Fact, FactRef, FactResolver, Facts}
   alias Runic.Runner.Store.ETS
 
   setup do
@@ -43,6 +43,17 @@ defmodule Runic.Workflow.FactResolverTest do
     test "returns error when FactRef is not in store", %{resolver: resolver} do
       ref = %FactRef{hash: 999_999, ancestry: {1, 2}}
       assert {:error, :not_found} = FactResolver.resolve(ref, resolver)
+    end
+
+    test "rejects a stored value that does not match the payload digest", %{
+      resolver: resolver,
+      store_state: store_state
+    } do
+      fact = Fact.new(value: "expected", ancestry: {1, 2})
+      :ok = ETS.save_fact(fact.hash, "corrupt", store_state)
+
+      assert {:error, %Runic.Identity.IntegrityError{}} =
+               fact |> Facts.to_ref() |> FactResolver.resolve(resolver)
     end
 
     test "resolves a FactRef from the cache without hitting the store", %{store: store} do

--- a/test/workflow/identity_test.exs
+++ b/test/workflow/identity_test.exs
@@ -1,0 +1,189 @@
+defmodule Runic.Workflow.IdentityTest do
+  use ExUnit.Case, async: false
+
+  require Runic
+
+  alias Runic.Workflow
+  alias Runic.Workflow.{Components, Fact, FactRef, IdentityConflictError, Step}
+
+  @max_phash 4_294_967_296
+
+  describe "phash2_64_v1" do
+    test "combines the primary hash with a domain-separated secondary hash" do
+      term = {%{answer: 42}, {:producer, :parent}}
+      primary = :erlang.phash2(term, @max_phash)
+      secondary = :erlang.phash2({:phash2_64_v1, :secondary, term}, @max_phash)
+
+      assert Components.hash_scheme() == :phash2_64_v1
+      assert Components.fact_hash(term) == primary * @max_phash + secondary
+      assert Components.fact_hash(term) in 0..(Integer.pow(2, 64) - 1)
+    end
+
+    test "separates the issue 16 Step.new collision and preserves both results" do
+      left =
+        Step.new(
+          name: "left",
+          hash: "probe-step-11396",
+          work: fn _input -> %{value: 11_396} end
+        )
+
+      right =
+        Step.new(
+          name: "right",
+          hash: "probe-step-19508",
+          work: fn _input -> %{value: 19_508} end
+        )
+
+      run = run_parallel(left, right, %{})
+      left_basis = {run.left.result.value, run.left.result.ancestry}
+      right_basis = {run.right.result.value, run.right.result.ancestry}
+
+      assert :erlang.phash2(left_basis, @max_phash) ==
+               :erlang.phash2(right_basis, @max_phash)
+
+      refute run.left.result.hash == run.right.result.hash
+
+      assert result_values(run.workflow, ["left", "right"]) == %{
+               "left" => %{value: 11_396},
+               "right" => %{value: 19_508}
+             }
+    end
+
+    @tag timeout: 30_000
+    test "separates a primary collision produced by macro-built steps" do
+      left = Runic.step(fn _input -> %{value: context(:value)} end, name: :left)
+      right = Runic.step(fn _input -> %{value: context(:value)} end, name: :right)
+      root_hash = Fact.new(value: %{}).hash
+      {left_value, right_value, primary_hash} = find_primary_collision(left, right, root_hash)
+
+      run =
+        run_parallel(left, right, %{
+          left: %{value: left_value},
+          right: %{value: right_value}
+        })
+
+      assert div(run.left.result.hash, @max_phash) == primary_hash
+      assert div(run.right.result.hash, @max_phash) == primary_hash
+      refute run.left.result.hash == run.right.result.hash
+
+      assert result_values(run.workflow, [:left, :right]) == %{
+               left: %{value: left_value},
+               right: %{value: right_value}
+             }
+    end
+  end
+
+  describe "guarded fact insertion" do
+    test "keeps an equivalent Fact insertion idempotent" do
+      original = Fact.new(hash: 101, value: :same, ancestry: {:producer, :parent}, meta: %{a: 1})
+      duplicate = %{original | meta: %{a: 2}}
+
+      workflow = Workflow.new() |> Workflow.log_fact(original) |> Workflow.log_fact(duplicate)
+
+      assert workflow.graph.vertices[101] == original
+    end
+
+    test "keeps an equivalent FactRef insertion idempotent" do
+      ref = %FactRef{hash: 102, ancestry: {:producer, :parent}}
+
+      workflow = Workflow.new() |> Workflow.log_fact(ref) |> Workflow.log_fact(ref)
+
+      assert workflow.graph.vertices[102] == ref
+    end
+
+    test "raises before replacing a distinct Fact at the same identity" do
+      original = Fact.new(hash: 103, value: :first, ancestry: {:producer, :parent})
+      conflicting = Fact.new(hash: 103, value: :second, ancestry: {:producer, :parent})
+      workflow = Workflow.new() |> Workflow.log_fact(original)
+
+      error =
+        assert_raise IdentityConflictError, fn ->
+          Workflow.log_fact(workflow, conflicting)
+        end
+
+      assert error.identity == 103
+      assert error.context == :log_fact
+      assert error.existing.value_type == :atom
+      assert error.incoming.value_type == :atom
+      assert workflow.graph.vertices[103] == original
+    end
+
+    test "fails closed when a Fact and FactRef claim the same identity" do
+      fact = Fact.new(hash: 104, value: :full, ancestry: {:producer, :parent})
+      ref = %FactRef{hash: 104, ancestry: fact.ancestry}
+
+      assert_raise IdentityConflictError, fn ->
+        Workflow.new() |> Workflow.log_fact(fact) |> Workflow.log_fact(ref)
+      end
+
+      assert_raise IdentityConflictError, fn ->
+        Workflow.new() |> Workflow.log_fact(ref) |> Workflow.log_fact(fact)
+      end
+    end
+
+    test "rejects a Fact identity already occupied by a component" do
+      step = Step.new(name: :occupied, hash: 105, work: &Function.identity/1)
+      fact = Fact.new(hash: 105, value: :fact, ancestry: nil)
+      workflow = Workflow.new() |> Workflow.add(step)
+
+      error =
+        assert_raise IdentityConflictError, fn ->
+          Workflow.log_fact(workflow, fact)
+        end
+
+      assert error.existing == %{type: Step, hash: 105}
+      assert error.incoming.type == Fact
+    end
+  end
+
+  defp find_primary_collision(left, right, root_hash) do
+    search_range = 0..250_000
+
+    left_hashes =
+      Map.new(search_range, fn value ->
+        basis = {%{value: value}, {left.hash, root_hash}}
+        {:erlang.phash2(basis, @max_phash), value}
+      end)
+
+    Enum.find_value(search_range, fn right_value ->
+      basis = {%{value: right_value}, {right.hash, root_hash}}
+      hash = :erlang.phash2(basis, @max_phash)
+
+      case Map.fetch(left_hashes, hash) do
+        {:ok, left_value} when left_value != right_value ->
+          {left_value, right_value, hash}
+
+        _other ->
+          nil
+      end
+    end) || flunk("expected a primary phash2 collision in the search range")
+  end
+
+  defp run_parallel(left, right, context) do
+    workflow =
+      Workflow.new("identity_collision")
+      |> Workflow.add(left)
+      |> Workflow.add(right)
+      |> Workflow.put_run_context(context)
+      |> Workflow.plan_eagerly(%{})
+
+    {workflow, runnables} = Workflow.prepare_for_dispatch(workflow)
+    left_runnable = Enum.find(runnables, &(&1.node.name == left.name))
+    right_runnable = Enum.find(runnables, &(&1.node.name == right.name))
+    executed_left = Workflow.execute_runnable(left_runnable)
+    executed_right = Workflow.execute_runnable(right_runnable)
+
+    workflow =
+      workflow
+      |> Workflow.apply_runnable(executed_left)
+      |> Workflow.apply_runnable(executed_right)
+
+    %{workflow: workflow, left: executed_left, right: executed_right}
+  end
+
+  defp result_values(workflow, names) do
+    workflow
+    |> Workflow.results(names, facts: true, all: true)
+    |> Map.new(fn {name, facts} -> {name, facts |> List.first() |> Map.fetch!(:value)} end)
+  end
+end

--- a/test/workflow/identity_test.exs
+++ b/test/workflow/identity_test.exs
@@ -4,19 +4,22 @@ defmodule Runic.Workflow.IdentityTest do
   require Runic
 
   alias Runic.Workflow
+  alias Runic.Identity
   alias Runic.Workflow.{Components, Fact, FactRef, IdentityConflictError, Step}
 
   @max_phash 4_294_967_296
 
-  describe "phash2_64_v1" do
-    test "combines the primary hash with a domain-separated secondary hash" do
+  describe "sha256_v1" do
+    test "returns a typed, domain-separated SHA-256 identity" do
       term = {%{answer: 42}, {:producer, :parent}}
-      primary = :erlang.phash2(term, @max_phash)
-      secondary = :erlang.phash2({:phash2_64_v1, :secondary, term}, @max_phash)
 
-      assert Components.hash_scheme() == :phash2_64_v1
-      assert Components.fact_hash(term) == primary * @max_phash + secondary
-      assert Components.fact_hash(term) in 0..(Integer.pow(2, 64) - 1)
+      assert Components.hash_scheme() == :sha256_v1
+
+      assert %Identity{scheme: :sha256, version: 1, domain: :component_definition} =
+               Components.fact_hash(term)
+
+      assert Components.fact_hash(term) == Components.fact_hash(term)
+      refute Components.fact_hash(term) == Identity.digest(:payload, term)
     end
 
     test "separates the issue 16 Step.new collision and preserves both results" do
@@ -35,12 +38,8 @@ defmodule Runic.Workflow.IdentityTest do
         )
 
       run = run_parallel(left, right, %{})
-      left_basis = {run.left.result.value, run.left.result.ancestry}
-      right_basis = {run.right.result.value, run.right.result.ancestry}
-
-      assert :erlang.phash2(left_basis, @max_phash) ==
-               :erlang.phash2(right_basis, @max_phash)
-
+      assert %Identity{domain: :fact_occurrence} = run.left.result.hash
+      assert %Identity{domain: :fact_occurrence} = run.right.result.hash
       refute run.left.result.hash == run.right.result.hash
 
       assert result_values(run.workflow, ["left", "right"]) == %{
@@ -62,8 +61,13 @@ defmodule Runic.Workflow.IdentityTest do
           right: %{value: right_value}
         })
 
-      assert div(run.left.result.hash, @max_phash) == primary_hash
-      assert div(run.right.result.hash, @max_phash) == primary_hash
+      left_basis = {%{value: left_value}, {left.hash, root_hash}}
+      right_basis = {%{value: right_value}, {right.hash, root_hash}}
+
+      assert :erlang.phash2(left_basis, @max_phash) == primary_hash
+      assert :erlang.phash2(right_basis, @max_phash) == primary_hash
+      assert %Identity{domain: :fact_occurrence} = run.left.result.hash
+      assert %Identity{domain: :fact_occurrence} = run.right.result.hash
       refute run.left.result.hash == run.right.result.hash
 
       assert result_values(run.workflow, [:left, :right]) == %{
@@ -106,6 +110,23 @@ defmodule Runic.Workflow.IdentityTest do
       assert error.existing.value_type == :atom
       assert error.incoming.value_type == :atom
       assert workflow.graph.vertices[103] == original
+    end
+
+    test "verifies full SHA identity evidence on duplicate insertion" do
+      original = Fact.new(value: :first, ancestry: {:producer, :parent})
+
+      conflicting =
+        Fact.new(hash: original.id, value: :second, ancestry: original.ancestry)
+
+      workflow = Workflow.new() |> Workflow.log_fact(original)
+
+      error =
+        assert_raise IdentityConflictError, fn ->
+          Workflow.log_fact(workflow, conflicting)
+        end
+
+      assert error.identity == original.id
+      refute error.existing.payload_digest == error.incoming.payload_digest
     end
 
     test "fails closed when a Fact and FactRef claim the same identity" do

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -1293,7 +1293,7 @@ defmodule WorkflowTest do
         assert not is_nil(name)
         assert not is_nil(value)
         assert is_atom(name) or is_binary(name)
-        assert is_integer(value)
+        assert %Runic.Identity{domain: :component_definition} = value
       end
 
       for node <- Multigraph.vertices(wrk.graph) do


### PR DESCRIPTION
Distinct workflow Facts could silently alias when their 32-bit phash2 hashes collided. This PR replaces generated correctness-facing hashes with versioned, domain-separated SHA-256 identities backed by a Runic-owned canonical codec, and verifies Fact identity evidence before graph insertion. Both `Step.new` and `Runic.step` are covered by the issue #16 reproduction and regression tests.

Equal fan-out values can share a payload digest while retaining distinct Fact occurrences. Explicit Fact IDs are preserved and validated. Workflow artifact identities include semantic component projections, and rebuild retains recorded authored closures. Events, replay, FactRef hydration, and the transitional ETS/Mnesia payload storage callbacks carry the new identities; hydration verifies payload digests.

Canonical structs have a dedicated type tag so they cannot alias ordinary tuples. Binding-dependent macros share the closure binding projection, including external function captures. Cytoscape emits full tagged identity strings for JSON serialization.

This combined PR includes the commits from #17 and supersedes it. The final implementation uses SHA-256; the composite phash2 stopgap remains in the development history and planning documentation.

## Validation

- `mix test`: 55 doctests, 1,411 tests, 0 failures, 13 skipped
- 11 regression tests cover canonical separation, macro construction, replay, artifact semantics, JSON serialization, and explicit Fact IDs
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`

One initial full-suite run hit the existing 10 ms timeout/retry test; it passed in isolation and in the final full-suite run. PR consolidation changes metadata only; the validated code remains at `5f9b6ad`.

## Compatibility and remaining scope

Frozen byte vectors, a reproducible benchmark, and implementation/migration notes are in `.docs`. This is an alpha identity contract change: existing persisted workflows need the documented reset/rebuild or migration boundary. Artifacts from earlier unreleased drafts affected by struct encoding, tuple binding projections, or workflow artifact documents must also be rebuilt.

Authored node-occurrence wrappers and the distributed execution, command, transaction, event-position, authority-epoch, Journal, and ExecutionBackend contracts remain part of the `zw/dist-runtime` effort.

Closes #16.
